### PR TITLE
Updated style linting  rules and made changes

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -6,6 +6,17 @@
       {
         "ignoreFontFamilies": ["sasicons-103018"]
       }
-    ]
+    ],
+    "shorthand-property-no-redundant-values": [null],
+    "rule-empty-line-before": [null],
+    "selector-pseudo-element-colon-notation": ["single"],
+    "comment-empty-line-before": [null],
+    "color-hex-length": ["long"],
+    "at-rule-empty-line-before": [null],
+    "color-function-notation": ["modern"],
+    "alpha-value-notation": ["number"],
+    "font-family-name-quotes": ["always-unless-keyword"],
+    "custom-property-pattern": [null],
+    "selector-class-pattern": [null]
   }
 }

--- a/blocks/Vidyard/vidyard.css
+++ b/blocks/Vidyard/vidyard.css
@@ -47,7 +47,7 @@
   padding: 0;
 }
 
-.embed .embed-placeholder-play button::before {
+.embed .embed-placeholder-play button:before {
   content: "";
   display: block;
   box-sizing: border-box;

--- a/blocks/accordion/accordion.css
+++ b/blocks/accordion/accordion.css
@@ -30,7 +30,7 @@
   display: none;
 }
 
-.accordion details summary::after {
+.accordion details summary:after {
   content: "";
   position: absolute;
   top: 50%;
@@ -43,7 +43,7 @@
   transition: transform 0.2s;
 }
 
-.accordion details[open] summary::after {
+.accordion details[open] summary:after {
   transform: translateY(-50%) rotate(-45deg);
 }
 

--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -56,7 +56,7 @@
   padding: 1rem;
   margin: 1.5rem 3rem;
   color: white;
-  background-color: rgba(0 0 0 / 50%);
+  background-color: rgba(0 0 0 / 0.5);
   position: relative;
   width: var(--slide-content-width, auto);
 }
@@ -72,13 +72,13 @@
   height: 1rem;
   padding: 0;
   border-radius: 1rem;
-  background-color: rgba(0 0 0 / 25%);
+  background-color: rgba(0 0 0 / 0.25);
 }
 
 .carousel .carousel-slide-indicator button:disabled,
 .carousel .carousel-slide-indicator button:hover,
 .carousel .carousel-slide-indicator button:focus-visible {
-  background-color: rgba(0 0 0 / 80%);
+  background-color: rgba(0 0 0 / 0.8);
 }
 
 .carousel .carousel-slide-indicator span,
@@ -115,15 +115,15 @@
   width: 2rem;
   height: 2rem;
   position: relative;
-  background-color: rgba(0 0 0 / 25%);
+  background-color: rgba(0 0 0 / 0.25);
 }
 
 .carousel .carousel-navigation-buttons button:hover,
 .carousel .carousel-navigation-buttons button:focus-visible {
-  background-color: rgba(0 0 0 / 80%);
+  background-color: rgba(0 0 0 / 0.8);
 }
 
-.carousel .carousel-navigation-buttons button::after {
+.carousel .carousel-navigation-buttons button:after {
   display: block;
   content: "";
   border: 3px white solid;
@@ -137,7 +137,7 @@
   transform: translate(-50%, -50%) rotate(-135deg);
 }
 
-.carousel .carousel-navigation-buttons button.slide-next::after {
+.carousel .carousel-navigation-buttons button.slide-next:after {
   transform: translate(-50%, -50%)  rotate(45deg);
   left: calc(50% - 3px);
 }
@@ -153,7 +153,7 @@
     height: 3rem;
   }
 
-  .carousel .carousel-navigation-buttons button::after {
+  .carousel .carousel-navigation-buttons button:after {
     width: 1rem;
     height: 1rem;
   }

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -5,7 +5,7 @@
 
 .columns50 {
   max-width: 1280px;
-  margin: 0em auto 2em auto;
+  margin: 0 auto 2em auto;
   text-align: left;
   div {
     padding: 1% .9%;
@@ -15,6 +15,24 @@
 
 .columns img {
   width: 100%;
+}
+
+.promo-col {
+  background: #ececec;
+  text-align: left;
+  margin: 0 auto; 
+  div {
+    max-width: 1280px;
+    margin: 0 auto;
+    padding: 1em 0;
+    p {
+      font-size: .8em;
+    }
+  }
+  h3 {
+    text-align: center;
+    margin: 0;
+  }
 }
 
 .columns > div > div {
@@ -54,8 +72,8 @@
   p {
     font-size: 1.6rem;
     text-transform: uppercase;
-    color: #fff;
-    border-top: 1px solid #777;
+    color: #ffffff;
+    border-top: 1px solid #777777;
     display: block;
     padding-top: 1.2em;
     padding-bottom: 1em;
@@ -87,7 +105,7 @@
     color: #c1c1c1;
     padding: 0 0 1em .25em;
     &:hover {
-      color: #fff;
+      color: #ffffff;
       transition: .3s;
     } 
   }
@@ -103,8 +121,8 @@
     text-indent: -1em;
   }
 
-  li::before {
-    color: #bbb;
+  li:before {
+    color: #bbbbbb;
     font-family: 'sasicons-103018' !important;
     content: '';
     font-size: 70%;
@@ -123,7 +141,7 @@
     margin: 5px 0;
     cursor: pointer;
     line-height: 2;
-    padding: 0px;
+    padding: 0;
     position: relative;
     z-index: 1;
     text-align: left;
@@ -137,28 +155,20 @@
     content: " > ";
   }
 }
-.promo-col {
-  background: #ececec;
-  text-align: left;
-  margin: 0em auto; 
-  div {
-    max-width: 1280px;
-    margin: 0 auto;
-    padding: 1em 0;
-    p {
-      font-size: .8em;
-    }
-  }
-  h3 {
-    text-align: center;
-    margin: 0;
-  }
-}
 /* hero columns quote */
 .promo-col-colors {
   background: linear-gradient(45deg, #242d35 15%, #44545d 95%);
-  margin: 0em auto;
+  margin: 0 auto;
   padding: 0 0 4em 0;
+  h3, div {
+    text-align: center;
+    margin: .5em auto 0 auto;
+    margin-bottom: -.5em;
+    padding: 0 1em .5em;
+    color: #ffffff;
+    max-width: 1280px;
+  }
+
   div:nth-child(1) {
     color: #f5ba55;
   }
@@ -172,14 +182,5 @@
 
   div > div:nth-child(3) {
     color: #c479ba;
-  }
-
-  h3, div {
-    text-align: center;
-    margin-bottom: -.5em;
-    padding: 0 1em .5em;
-    color: #ffffff;
-    margin: .5em auto 0em auto;
-    max-width: 1280px;
   }
 }

--- a/blocks/embed/embed.css
+++ b/blocks/embed/embed.css
@@ -47,7 +47,7 @@
   padding: 0;
 }
 
-.embed .embed-placeholder-play button::before {
+.embed .embed-placeholder-play button:before {
   content: "";
   display: block;
   box-sizing: border-box;

--- a/blocks/footer/footer.css
+++ b/blocks/footer/footer.css
@@ -21,7 +21,7 @@ div.section.copyright {
   width: 100%;
   height: 50px;
   padding: 10px;
-  background-color: #fff;
+  background-color: #ffffff;
   .default-content-wrapper {
     ul {
       display: flex;
@@ -29,12 +29,12 @@ div.section.copyright {
       margin: 0;
       padding-left: 0;
       li {
-        color: #333;
+        color: #333333;
         text-decoration: none;
         /* padding-right: 10px; */
         a {
           color: var(--blue);
-          border-left: 1px solid #333;
+          border-left: 1px solid #333333;
           margin-left: 1em;
           padding-left: 1em;
           &:hover {
@@ -64,5 +64,5 @@ div.section.copyright {
 }
 
 .footer-wrapper {
-  background-color: #333;
+  background-color: #333333;
 }

--- a/blocks/form/form.css
+++ b/blocks/form/form.css
@@ -82,7 +82,7 @@
   order: 1;
 }
 
-.form input[required] + label::after {
+.form input[required] + label:after {
   content: "*";
   color: firebrick;
   margin-inline-start: 1ch;
@@ -110,7 +110,7 @@
   border-radius: 30px;
 }
 
-.form .toggle-wrapper .slider::before {
+.form .toggle-wrapper .slider:before {
   position: absolute;
   content: "";
   height: 20px;
@@ -131,6 +131,6 @@
   outline-offset: 2px;
 }
 
-.form .toggle-wrapper input:checked + .slider::before {
+.form .toggle-wrapper input:checked + .slider:before {
   transform: translateX(24px);
 }

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -20,9 +20,9 @@ header nav {
   font-family: var(--body-font-family);
 }
 
-/* mobile */
+/* mobile
 @media (width >= 600px) {
-}
+} */
 
 /* tablet */
 @media (width < 900px) {
@@ -123,34 +123,34 @@ header nav .nav-hamburger button {
 }
 
 header nav .nav-hamburger-icon,
-header nav .nav-hamburger-icon::before,
-header nav .nav-hamburger-icon::after {
+header nav .nav-hamburger-icon:before,
+header nav .nav-hamburger-icon:after {
   box-sizing: border-box;
   display: block;
   position: relative;
   width: 20px;
 }
 
-header nav .nav-hamburger-icon::before,
-header nav .nav-hamburger-icon::after {
+header nav .nav-hamburger-icon:before,
+header nav .nav-hamburger-icon:after {
   content: '';
   position: absolute;
   background: currentcolor;
 }
 
 header nav[aria-expanded="false"] .nav-hamburger-icon,
-header nav[aria-expanded="false"] .nav-hamburger-icon::before,
-header nav[aria-expanded="false"] .nav-hamburger-icon::after {
+header nav[aria-expanded="false"] .nav-hamburger-icon:before,
+header nav[aria-expanded="false"] .nav-hamburger-icon:after {
   height: 2px;
   border-radius: 2px;
   background: currentcolor;
 }
 
-header nav[aria-expanded="false"] .nav-hamburger-icon::before {
+header nav[aria-expanded="false"] .nav-hamburger-icon:before {
   top: -6px;
 }
 
-header nav[aria-expanded="false"] .nav-hamburger-icon::after {
+header nav[aria-expanded="false"] .nav-hamburger-icon:after {
   top: 6px;
 }
 
@@ -158,8 +158,8 @@ header nav[aria-expanded="true"] .nav-hamburger-icon {
   height: 22px;
 }
 
-header nav[aria-expanded="true"] .nav-hamburger-icon::before,
-header nav[aria-expanded="true"] .nav-hamburger-icon::after {
+header nav[aria-expanded="true"] .nav-hamburger-icon:before,
+header nav[aria-expanded="true"] .nav-hamburger-icon:after {
   top: 3px;
   left: 1px;
   transform: rotate(45deg);
@@ -169,7 +169,7 @@ header nav[aria-expanded="true"] .nav-hamburger-icon::after {
   border-radius: 2px;
 }
 
-header nav[aria-expanded="true"] .nav-hamburger-icon::after {
+header nav[aria-expanded="true"] .nav-hamburger-icon:after {
   top: unset;
   bottom: 3px;
   transform: rotate(-45deg);
@@ -272,7 +272,7 @@ header nav .nav-sections ul > li > ul > li {
     cursor: pointer;
   }
 
-  header nav .nav-sections .nav-drop::after {
+  header nav .nav-sections .nav-drop:after {
     content: '';
     display: inline-block;
     position: absolute;
@@ -286,7 +286,7 @@ header nav .nav-sections ul > li > ul > li {
     border-width: 1px 1px 0 0;
   }
 
-  header nav .nav-sections .nav-drop[aria-expanded="true"]::after {
+  header nav .nav-sections .nav-drop[aria-expanded="true"]:after {
     top: 50%;
     transform: rotate(315deg);
   }
@@ -298,29 +298,8 @@ header nav .nav-sections ul > li > ul > li {
     font-size: var(--body-font-size-xs);
   }
 
-  header nav .nav-sections .default-content-wrapper > ul > li {
-    flex: 0 1 auto;
-    position: relative;
-    font-weight: 500;
-  }
-
-  header nav .nav-sections .default-content-wrapper > ul > li > ul {
-    display: none;
-    position: relative;
-    &::before {
-      width: 0; 
-      height: 0; 
-      top: 0 !important;
-      left: 50% !important;
-      transform: translateX(-50%);
-      border-left: 6px solid transparent;
-      border-right: 6px solid transparent;
-      border-top: 6px solid var(--orange);
-    }
-  }
-
   header nav .nav-sections .default-content-wrapper > ul > li[aria-expanded="false"] {
-    border-bottom: 3px solid rgba(0,0,0,0.0);
+    border-bottom: 3px solid rgb(0 0 0 / 0);
   }
   header nav .nav-sections .default-content-wrapper > ul > li[aria-expanded="true"] {
     border-bottom: 3px solid var(--orange);
@@ -342,18 +321,10 @@ header nav .nav-sections ul > li > ul > li {
     }
   }
 
-  header nav .nav-sections .default-content-wrapper > ul > li > ul::before {
-    content: '';
-    position: absolute;
-    top: -8px;
-    left: 8px;
-    width: 0;
-    height: 0;
-    border-left: 8px solid transparent;
-    border-right: 8px solid transparent;
-    border-bottom: 8px solid var(--light-color);
-  }
   header nav .nav-sections .default-content-wrapper > ul > li  {
+    flex: 0 1 auto;
+    position: relative;
+    font-weight: 500;
     p {
       line-height: 62px;
       padding-top: 4px;
@@ -368,8 +339,8 @@ header nav .nav-sections ul > li > ul > li {
           padding: 6px 16px;
           font-size: 16px;
           border-radius: 5px;
-          color: #fff;
-          font-family: "anova-bold";
+          color: #ffffff;
+          font-family: "anova-bold", sans-serif;
         }
       }
       &:hover {

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -27,7 +27,6 @@ main .hero-container {
     position: relative;
     max-width: 1280px;
     margin: 0 auto;
-    text-align: left;
     display: block;
     z-index: 100;
     text-align: left;
@@ -69,7 +68,6 @@ main .hero-container {
     }
   }
   a.button {
-    border: white 1px solid;
     background: white;
     color: #0378cd;
     border: none;

--- a/blocks/hubspot/hubspot.css
+++ b/blocks/hubspot/hubspot.css
@@ -47,7 +47,7 @@
   padding: 0;
 }
 
-.embed .embed-placeholder-play button::before {
+.embed .embed-placeholder-play button:before {
   content: "";
   display: block;
   box-sizing: border-box;

--- a/blocks/listgroup/listgroup.css
+++ b/blocks/listgroup/listgroup.css
@@ -52,7 +52,7 @@ ul.list-tile {
 
 .listgroup ul.list-tile>li a .navigation-title {
   font-size: 13px;
-  font-family: anova-med, Arial, Helvetica, sans-serif;
+  font-family: "anova-med", "Arial", "Helvetica", sans-serif;
   font-weight: normal;
   color: var(--gray7);
   display: block;
@@ -63,8 +63,7 @@ ul.list-tile {
 }
 
 .title {
-  color: #000;
-  font-family: anova-reg, Arial, Helvetica, sans-serif;
+  font-family: "anova-reg", "Arial", "Helvetica", sans-serif;
   font-weight: normal;
   font-size: 1.6 rem;
   padding: 0 0 .25em;
@@ -73,6 +72,6 @@ ul.list-tile {
 }
 
 .abstract {
-  color: #000;
+  color: #000000;
   font-size: .8rem;
 }

--- a/blocks/modal/modal.css
+++ b/blocks/modal/modal.css
@@ -6,7 +6,7 @@ body.modal-open {
   --dialog-border-radius: 16px;
 
   overscroll-behavior: none;
-  border: 1px solid #ccc;
+  border: 1px solid #cccccc;
   border-radius: var(--dialog-border-radius);
   width: 100vw;
 }
@@ -30,7 +30,7 @@ body.modal-open {
 }
 
 .modal dialog::backdrop {
-  background-color: rgb(0 0 0 / 50%);
+  background-color: rgb(0 0 0 / 0.5);
 }
 
 .modal .close-button {

--- a/blocks/quote/quote.css
+++ b/blocks/quote/quote.css
@@ -1,16 +1,12 @@
-/* hero columns quote - touch file */
 .quote blockquote {
-  margin: 0 auto;
   padding: 0 32px;
   max-width: 960px;
   display: block;
-
   margin:4.5em auto; /*  messing around */
 }
-
 .quote blockquote .quote-quotation {
   text-align: center;
-  font-family: anova-light,Arial,Helvetica,sans-serif;
+  font-family: "anova-light","Arial","Helvetica",sans-serif;
   font-weight: normal;
   font-size: 1.8rem; /*  messing around */
   color: #643695;
@@ -20,64 +16,30 @@
   line-height: 1.2em;
 }
 
+
 .quote blockquote .quote-quotation > :first-child {
   text-indent: -0.6ch;
 }
 
-.quote blockquote .quote-quotation > :first-child::before,
-.quote blockquote .quote-quotation > :last-child::after {
+.quote blockquote .quote-quotation > :first-child:before,
+.quote blockquote .quote-quotation > :last-child:after {
   line-height: 0;
 }
 
-.quote blockquote .quote-quotation > :first-child::before {
+.quote blockquote .quote-quotation > :first-child:before {
   content: '\201C';
-  font-family: Georgia, cursive;
+  font-family: "Georgia", cursive;
   font-size: 800%;
   width: 1em;
   position: absolute;
   top: 0.275em;
   left: -0.300em; /*  messing around */
   opacity: .2; /*  messing around */
- /* color: #f2f2f2; */.quote blockquote {
-  margin: 0 auto;
-  padding: 0 32px;
-  max-width: 960px;
-  display: block;
-  margin: 4.5em auto; /*  messing around */
+ /* color: #f2f2f2; */
 }
-.quote blockquote .quote-quotation {
-  text-align: center;
-  font-family: anova-light, Arial, Helvetica, sans-serif;
-  font-weight: normal;
-  font-size: 1.8rem; /*  messing around */
-  color: #643695;
-  margin: 20px;
-  position: relative;
-  padding: 0;
-  line-height: 1.2em;
-}
-.quote blockquote .quote-quotation > :first-child {
-  text-indent: -0.6ch;
-}
-.quote blockquote .quote-quotation > :first-child::before, .quote blockquote .quote-quotation > :last-child::after {
-  line-height: 0;
-}
-.quote blockquote .quote-quotation > :first-child::before {
-  content: '\201C';
-  font-family: Georgia, cursive;
-  font-size: 800%;
-  width: 1em;
-  position: absolute;
-  top: 0.275em;
-  left: -0.300em; /*  messing around */
-  opacity: .2; /*  messing around */
-  /* color: #f2f2f2; */
-  color: #9c9c9c; /*  messing around */
-  z-index: -1;
-}
-* *.quote blockquote .quote-quotation > :last-child::after {
+* *.quote blockquote .quote-quotation > :last-child:after {
   content: '\201D';
-  font-family: Georgia, cursive;
+  font-family: "Georgia", cursive;
   width: 0;
   height: 0;
   font-size: 800%;
@@ -96,30 +58,26 @@
   margin: -1em 0 0 0; /*  messing around */
   padding: 0 0 1em;
   line-height: 125%;
-  font-size: 1.6rem;
-  color: #333;
+  color: #333333;
   font-size: .8em; /*  messing around */
 }
 .quote blockquote .quote-attribution strong {
-  font-family: anova-med, Arial, Helvetica, sans-serif;
+  font-family: "anova-med", "Arial", "Helvetica", sans-serif;
   font-weight: normal;
   text-align: center;
   margin: 0;
   padding: 0 0 1em;
   line-height: 150%;
   font-size: 1.6rem;
-  color: #333;
+  color: #333333;
 }
-.quote blockquote .quote-attribution > :first-child::before {
+.quote blockquote .quote-attribution > :first-child:before {
   content: "";
 }
-  color: #9c9c9c; /*  messing around */
-  z-index: -1;
-}*
 
-*.quote blockquote .quote-quotation > :last-child::after {
+*.quote blockquote .quote-quotation > :last-child:after {
   content: '\201D';
-  font-family: Georgia, cursive;
+  font-family: "Georgia", cursive;
   width: 0;
   height: 0;
   font-size: 800%;
@@ -133,31 +91,4 @@
   opacity: .2; /*  messing around */
   color: #9c9c9c; /*  messing around */
 
-}
-
-.quote blockquote .quote-attribution {
-  text-align: center;
-  margin: -1em 0 0 0; /*  messing around */
-  padding: 0 0 1em;
-  line-height: 125%;
-  font-size: 1.6rem;
-  color: #333;
-
-  font-size: .8em; /*  messing around */
-}
-
-.quote blockquote .quote-attribution strong {
-  font-family: anova-med,Arial,Helvetica,sans-serif;
-  font-weight: normal;
-  text-align: center;
-  margin: 0;
-  padding: 0 0 1em;
-  line-height: 150%;
-  font-size: 1.6rem;
-  color: #333;
-}
-
-
-.quote blockquote .quote-attribution > :first-child::before {
-  content: "";
 }

--- a/blocks/search/search.css
+++ b/blocks/search/search.css
@@ -11,7 +11,7 @@
     text-align: left;
     border: 1px solid #CECECE;
     width: 200px;
-    font-family: anova-light,Arial,Helvetica,sans-serif;
+    font-family: "anova-light","Arial","Helvetica",sans-serif;
 }
 
 .search .search-box input::placeholder {
@@ -20,7 +20,7 @@
   font-size: smaller;
 }
 
-.search .search-box::after {
+.search .search-box:after {
   /* stylelint-disable-next-line */
     font-family: 'sasicons-103018' !important;
     content: "\e61b";

--- a/blocks/styled-columns/styled-columns.css
+++ b/blocks/styled-columns/styled-columns.css
@@ -1,10 +1,10 @@
 
 .styled-columns {
     --blue: #0033ab;
-    --light-blue: #0be;
+    --light-blue: #00bbee;
     --yellow: #fcbd30;
-    --white: #fff;
-    --gray: #eee;
+    --white: #ffffff;
+    --gray: #eeeeee;
     --light-gray: #767676;
   }
   

--- a/blocks/tabs/tabs.css
+++ b/blocks/tabs/tabs.css
@@ -3,7 +3,7 @@
   padding-top: 1em;
   border-bottom: 1px solid #d0d0d0;
   font-weight: normal;
-  font-family: anova-med,Arial,Helvetica,sans-serif;  ;
+  font-family: "anova-med","Arial","Helvetica",sans-serif;  ;
 }
 
 .tabs .tabs-list {
@@ -15,7 +15,7 @@
 .tabs .tabs-list h3 {
   color: #0378cd;
   line-height: 2.5em;
-  font-family: anova-med,Arial,Helvetica,sans-serif;
+  font-family: "anova-med","Arial","Helvetica",sans-serif;
   font-weight: normal;
   font-size: 1.4rem;
 }
@@ -25,7 +25,7 @@
   margin: 0;
   border: 1px solid var(--dark-color);
   border-radius: 0;
-  background-color: #fff;
+  background-color: #ffffff;
   color: initial;
   font-size: 1.4rem;
   font-weight: normal;
@@ -46,8 +46,8 @@
 
 .tabs .tabs-list .tabs-tab[aria-selected="true"] {
     border-color: #d0d0d0;
-    border-bottom-color: #FFF;
-    background: linear-gradient(180deg, #e4e4e4 0, #fff 50%);
+    border-bottom-color: #FFFFFF;
+    background: linear-gradient(180deg, #e4e4e4 0, #ffffff 50%);
     
 }
 
@@ -57,14 +57,14 @@
 .tabs .tabs-list .tabs-tab[aria-selected="false"]:focus {
   border: 1px solid #d0d0d0;
   border-bottom-color: #d0d0d0;
-  background: linear-gradient(0deg, #e4e4e4 0, #fff 50%);
+  background: linear-gradient(0deg, #e4e4e4 0, #ffffff 50%);
 }
 
 .tabs .tabs-panel {
   margin-top: -1px;
   padding: 0 16px;
   border-color: #d0d0d0;
-  border-bottom-color: #fff;
+  border-bottom-color: #ffffff;
   overflow: auto;
 }
 
@@ -91,7 +91,7 @@ div#tabpanel-standard.tabs-panel div table tbody tr td {
 }
 
 
-.tabs-panel a::before {
+.tabs-panel a:before {
 	font-family: "sasicons-103018", sans-serif !important;
   content: "\e616";
 	content: "\e616" "";

--- a/blocks/video/video.css
+++ b/blocks/video/video.css
@@ -57,7 +57,7 @@
   padding: 0;
 }
 
-.video .video-placeholder-play button::before {
+.video .video-placeholder-play button:before {
   content: "";
   display: block;
   box-sizing: border-box;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "lint:js": "eslint .",
     "lint:css": "stylelint blocks/**/*.css styles/*.css",
-    "lint": "npm run lint:js && npm run lint:css"
+    "lint": "npm run lint:js && npm run lint:css",
+    "lint:fix": "npm run lint:js && stylelint blocks/**/*.css styles/*.css --fix"
   },
   "repository": {
     "type": "git",

--- a/styles/fonts.css
+++ b/styles/fonts.css
@@ -1,5 +1,5 @@
 @font-face {
-  font-family: anova-regular;
+  font-family: "anova-regular";
   font-style: normal;
   font-weight: 700;
   font-display: swap;
@@ -8,7 +8,7 @@
 }
 
 @font-face {
-  font-family: anova-light;
+  font-family: "anova-light";
   font-style: normal;
   font-weight: 700;
   font-display: swap;
@@ -17,7 +17,7 @@
 }
 
 @font-face {
-  font-family: anova-bold;
+  font-family: "anova-bold";
   font-style: normal;
   font-weight: 400;
   font-display: swap;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -15,12 +15,12 @@ html { font-size: 62.5%; }
 
 :root {
   /* colors */
-  --text-color: #333;
+  --text-color: #333333;
   --link-color: #0378cd;
   --link-hover-color: #3aaafc;
-  --background-color: #fff;
-  --overlay-background-color: #eee;
-  --highlight-background-color: #ccc;
+  --background-color: #ffffff;
+  --overlay-background-color: #eeeeee;
+  --highlight-background-color: #cccccc;
   --blue: #0378cd;
   --orange: #ff5000;
   --blueLight:#61CAE5;
@@ -37,16 +37,16 @@ html { font-size: 62.5%; }
   --blueDark:#002753;
 
   /* JMP Brand neutral */
-  --white:#FFF;
+  --white:#FFFFFF;
   --grayDark:#172328;
   --grayMedium:#44545D;	
   --grayLight:#8F989E;
-  --black:#000;
-  --gray3:#333;
-  --gray5:#555;
-  --gray6:#666;
-  --gray7:#777;
-  --gray9:#999;
+  --black:#000000;
+  --gray3:#333333;
+  --gray5:#555555;
+  --gray6:#666666;
+  --gray7:#777777;
+  --gray9:#999999;
   --grayRule:#D0D0D0;
 
   /* Color variables */
@@ -82,7 +82,7 @@ html { font-size: 62.5%; }
 }
 
 @font-face {
-  font-family: roboto-fallback;
+  font-family: "roboto-fallback";
   size-adjust: 100.06%;
   ascent-override: 95%;
   src: local('Arial');
@@ -275,7 +275,7 @@ a.button:hover {
   /* npm run lint expects a modern color notation.  
   background: rgba(0, 0, 0, 40%);
   */
-  background: #0066;
+  background: #00006666;
 }
 
 /* Dark Button */
@@ -283,8 +283,8 @@ a.button:hover {
 .dark-button-center {
   a.button {
     text-align: center;
-    background: #0020;
-    border: 1px solid #fff;
+    background: #00002200;
+    border: 1px solid #ffffff;
     border-radius: 8px;
     min-width: 200px;
     margin: 0 auto;
@@ -297,14 +297,14 @@ a.button:hover {
 
   a.button:hover {
     color: #fcfcfc;
-    background: #0066;
+    background: #00006666;
     border: 1px solid black;
     min-width: 200px;
   }	
 }
 
 .sasfont  {
-  a::before {
+  a:before {
     color: #eea879;
     font-family: 'sasicons-103018' !important;
     content: '';
@@ -319,7 +319,7 @@ a.button:hover {
 
 .sub-capability-cards {
   ul {
-    background: rgba(0 0 0 / 2.5%);
+    background: rgba(0 0 0 / 0.025);
     column-count: 3;
     margin: 0 0 10px;
     padding: 5px 20px 20px;


### PR DESCRIPTION
@cra1go @andbrwn - I need you guys to take a quick look at this to make sure I didn't break anything you worked on. This was all to fix linting errors. There are still 3 left regarding no-descending-specificity, but I think they would require more changes than I feel comfortable making to get the order of priority right.

This is what is left: 
blocks/columns/columns.css
  163:3  ✖  Expected selector ".promo-col-colors div" to come before selector ".columns > div > div"  no-descending-specificity

blocks/header/header.css
  385:7  ✖  Expected selector "header nav .nav-tools > .default-content-wrapper > p" to come before selector    no-descending-specificity
            "header nav .nav-sections .default-content-wrapper > ul > li p"
  400:7  ✖  Expected selector "header nav .nav-tools > .default-content-wrapper > ul" to come before selector   no-descending-specificity
            "header nav .nav-sections .default-content-wrapper > ul > li[aria-expanded="true"] > ul"

Test URLs:
- Before: https://main--jmp-da--jmphlx.hlx.live/en/software/why-jmp
- After: https://linting-rules--jmp-da--jmphlx.hlx.live/en/software/why-jmp
