### PR TITLE
Tag plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@babel/core": "7.24.4",
         "@babel/eslint-parser": "7.24.1",
         "@esm-bundle/chai": "4.3.4-fix.0",
+        "@open-wc/testing": "4.0.0",
         "@web/test-runner": "^0.18.2",
         "@web/test-runner-commands": "^0.9.0",
         "chai": "5.1.0",
@@ -696,6 +697,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.1.tgz",
+      "integrity": "sha512-wx4aBmgeGvFmOKucFKY+8VFJSYZxs9poN3SDNQFF6lT6NrQUnHiPB2PWz2sc4ieEcAaYYzN+1uWahEeTq2aRIQ==",
+      "dev": true
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.4.tgz",
+      "integrity": "sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==",
+      "dev": true,
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0"
+      }
+    },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
@@ -738,6 +754,57 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@open-wc/dedupe-mixin": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@open-wc/dedupe-mixin/-/dedupe-mixin-1.4.0.tgz",
+      "integrity": "sha512-Sj7gKl1TLcDbF7B6KUhtvr+1UCxdhMbNY5KxdU5IfMFWqL8oy1ZeAcCANjoB1TL0AJTcPmcCFsCbHf8X2jGDUA==",
+      "dev": true
+    },
+    "node_modules/@open-wc/scoped-elements": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@open-wc/scoped-elements/-/scoped-elements-3.0.5.tgz",
+      "integrity": "sha512-q4U+hFTQQRyorJILOpmBm6PY2hgjCnQe214nXJNjbJMQ9EvT55oyZ7C8BY5aFYJkytUyBoawlMpZt4F2xjdzHw==",
+      "dev": true,
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.4.0",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@open-wc/semantic-dom-diff": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@open-wc/semantic-dom-diff/-/semantic-dom-diff-0.20.1.tgz",
+      "integrity": "sha512-mPF/RPT2TU7Dw41LEDdaeP6eyTOWBD4z0+AHP4/d0SbgcfJZVRymlIB6DQmtz0fd2CImIS9kszaMmwMt92HBPA==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^4.3.1",
+        "@web/test-runner-commands": "^0.9.0"
+      }
+    },
+    "node_modules/@open-wc/testing": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@open-wc/testing/-/testing-4.0.0.tgz",
+      "integrity": "sha512-KI70O0CJEpBWs3jrTju4BFCy7V/d4tFfYWkg8pMzncsDhD7TYNHLw5cy+s1FHXIgVFetnMDhPpwlKIPvtTQW7w==",
+      "dev": true,
+      "dependencies": {
+        "@esm-bundle/chai": "^4.3.4-fix.0",
+        "@open-wc/semantic-dom-diff": "^0.20.0",
+        "@open-wc/testing-helpers": "^3.0.0",
+        "@types/chai-dom": "^1.11.0",
+        "@types/sinon-chai": "^3.2.3",
+        "chai-a11y-axe": "^1.5.0"
+      }
+    },
+    "node_modules/@open-wc/testing-helpers": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@open-wc/testing-helpers/-/testing-helpers-3.0.1.tgz",
+      "integrity": "sha512-hyNysSatbgT2FNxHJsS3rGKcLEo6+HwDFu1UQL6jcSQUabp/tj3PyX7UnXL3H5YGv0lJArdYLSnvjLnjn3O2fw==",
+      "dev": true,
+      "dependencies": {
+        "@open-wc/scoped-elements": "^3.0.2",
+        "lit": "^2.0.0 || ^3.0.0",
+        "lit-html": "^2.0.0 || ^3.0.0"
       }
     },
     "node_modules/@puppeteer/browsers": {
@@ -1110,6 +1177,15 @@
       "integrity": "sha512-PatH4iOdyh3MyWtmHVFXLWCCIhUbopaltqddG9BzB+gMIzee2MJrvd+jouii9Z3wzQJruGWAm7WOMjgfG8hQlQ==",
       "dev": true
     },
+    "node_modules/@types/chai-dom": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@types/chai-dom/-/chai-dom-1.11.3.tgz",
+      "integrity": "sha512-EUEZI7uID4ewzxnU7DJXtyvykhQuwe+etJ1wwOiJyQRTH/ifMWKX+ghiXkxCUvNJ6IQDodf0JXhuP6zZcy2qXQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "*"
+      }
+    },
     "node_modules/@types/co-body": {
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/@types/co-body/-/co-body-6.1.3.tgz",
@@ -1327,6 +1403,37 @@
         "@types/node": "*",
         "@types/send": "*"
       }
+    },
+    "node_modules/@types/sinon": {
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.3.tgz",
+      "integrity": "sha512-j3uovdn8ewky9kRBG19bOwaZbexJu/XjtkHyjvUgt4xfPFz18dcORIMqnYh66Fx3Powhcr85NT5+er3+oViapw==",
+      "dev": true,
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinon-chai": {
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.12.tgz",
+      "integrity": "sha512-9y0Gflk3b0+NhQZ/oxGtaAJDvRywCa5sIyaVnounqLvmf93yBF4EgIRspePtkMs3Tr844nCclYMlcCNmLCvjuQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "*",
+        "@types/sinon": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
+      "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
+      "dev": true
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true
     },
     "node_modules/@types/ws": {
       "version": "7.4.7",
@@ -2079,6 +2186,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/axe-core": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.0.tgz",
+      "integrity": "sha512-Mr2ZakwQ7XUAjp7pAwQWRhhK8mQQ6JAaNWSjmjxil0R8BPioMtQsTLOolGYkji1rcL++3dCqZA3zWqpT+9Ew6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/b4a": {
       "version": "1.6.6",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.6.tgz",
@@ -2374,6 +2490,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/chai-a11y-axe": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/chai-a11y-axe/-/chai-a11y-axe-1.5.0.tgz",
+      "integrity": "sha512-V/Vg/zJDr9aIkaHJ2KQu7lGTQQm5ZOH4u1k5iTMvIXuSVlSuUo0jcSpSqf9wUn9zl6oQXa4e4E0cqH18KOgKlQ==",
+      "dev": true,
+      "dependencies": {
+        "axe-core": "^4.3.3"
       }
     },
     "node_modules/chalk": {
@@ -5421,6 +5546,37 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "node_modules/lit": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.2.0.tgz",
+      "integrity": "sha512-s6tI33Lf6VpDu7u4YqsSX78D28bYQulM+VAzsGch4fx2H0eLZnJsUBsPWmGYSGoKDNbjtRv02rio1o+UdPVwvw==",
+      "dev": true,
+      "dependencies": {
+        "@lit/reactive-element": "^2.0.4",
+        "lit-element": "^4.1.0",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.1.0.tgz",
+      "integrity": "sha512-gSejRUQJuMQjV2Z59KAS/D4iElUhwKpIyJvZ9w+DIagIQjfJnhR20h2Q5ddpzXGS+fF0tMZ/xEYGMnKmaI/iww==",
+      "dev": true,
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0",
+        "@lit/reactive-element": "^2.0.4",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.2.0.tgz",
+      "integrity": "sha512-pwT/HwoxqI9FggTrYVarkBKFN9MlTUpLrDHubTmW4SrkL3kkqW5gxwbxMMUnbbRHBC0WTZnYHcjDSCM559VyfA==",
+      "dev": true,
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -9152,6 +9308,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "@lit-labs/ssr-dom-shim": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.1.tgz",
+      "integrity": "sha512-wx4aBmgeGvFmOKucFKY+8VFJSYZxs9poN3SDNQFF6lT6NrQUnHiPB2PWz2sc4ieEcAaYYzN+1uWahEeTq2aRIQ==",
+      "dev": true
+    },
+    "@lit/reactive-element": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.4.tgz",
+      "integrity": "sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==",
+      "dev": true,
+      "requires": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0"
+      }
+    },
     "@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
@@ -9185,6 +9356,57 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
+      }
+    },
+    "@open-wc/dedupe-mixin": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@open-wc/dedupe-mixin/-/dedupe-mixin-1.4.0.tgz",
+      "integrity": "sha512-Sj7gKl1TLcDbF7B6KUhtvr+1UCxdhMbNY5KxdU5IfMFWqL8oy1ZeAcCANjoB1TL0AJTcPmcCFsCbHf8X2jGDUA==",
+      "dev": true
+    },
+    "@open-wc/scoped-elements": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@open-wc/scoped-elements/-/scoped-elements-3.0.5.tgz",
+      "integrity": "sha512-q4U+hFTQQRyorJILOpmBm6PY2hgjCnQe214nXJNjbJMQ9EvT55oyZ7C8BY5aFYJkytUyBoawlMpZt4F2xjdzHw==",
+      "dev": true,
+      "requires": {
+        "@open-wc/dedupe-mixin": "^1.4.0",
+        "lit": "^3.0.0"
+      }
+    },
+    "@open-wc/semantic-dom-diff": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@open-wc/semantic-dom-diff/-/semantic-dom-diff-0.20.1.tgz",
+      "integrity": "sha512-mPF/RPT2TU7Dw41LEDdaeP6eyTOWBD4z0+AHP4/d0SbgcfJZVRymlIB6DQmtz0fd2CImIS9kszaMmwMt92HBPA==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "^4.3.1",
+        "@web/test-runner-commands": "^0.9.0"
+      }
+    },
+    "@open-wc/testing": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@open-wc/testing/-/testing-4.0.0.tgz",
+      "integrity": "sha512-KI70O0CJEpBWs3jrTju4BFCy7V/d4tFfYWkg8pMzncsDhD7TYNHLw5cy+s1FHXIgVFetnMDhPpwlKIPvtTQW7w==",
+      "dev": true,
+      "requires": {
+        "@esm-bundle/chai": "^4.3.4-fix.0",
+        "@open-wc/semantic-dom-diff": "^0.20.0",
+        "@open-wc/testing-helpers": "^3.0.0",
+        "@types/chai-dom": "^1.11.0",
+        "@types/sinon-chai": "^3.2.3",
+        "chai-a11y-axe": "^1.5.0"
+      }
+    },
+    "@open-wc/testing-helpers": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@open-wc/testing-helpers/-/testing-helpers-3.0.1.tgz",
+      "integrity": "sha512-hyNysSatbgT2FNxHJsS3rGKcLEo6+HwDFu1UQL6jcSQUabp/tj3PyX7UnXL3H5YGv0lJArdYLSnvjLnjn3O2fw==",
+      "dev": true,
+      "requires": {
+        "@open-wc/scoped-elements": "^3.0.2",
+        "lit": "^2.0.0 || ^3.0.0",
+        "lit-html": "^2.0.0 || ^3.0.0"
       }
     },
     "@puppeteer/browsers": {
@@ -9429,6 +9651,15 @@
       "integrity": "sha512-PatH4iOdyh3MyWtmHVFXLWCCIhUbopaltqddG9BzB+gMIzee2MJrvd+jouii9Z3wzQJruGWAm7WOMjgfG8hQlQ==",
       "dev": true
     },
+    "@types/chai-dom": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@types/chai-dom/-/chai-dom-1.11.3.tgz",
+      "integrity": "sha512-EUEZI7uID4ewzxnU7DJXtyvykhQuwe+etJ1wwOiJyQRTH/ifMWKX+ghiXkxCUvNJ6IQDodf0JXhuP6zZcy2qXQ==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "*"
+      }
+    },
     "@types/co-body": {
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/@types/co-body/-/co-body-6.1.3.tgz",
@@ -9646,6 +9877,37 @@
         "@types/node": "*",
         "@types/send": "*"
       }
+    },
+    "@types/sinon": {
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.3.tgz",
+      "integrity": "sha512-j3uovdn8ewky9kRBG19bOwaZbexJu/XjtkHyjvUgt4xfPFz18dcORIMqnYh66Fx3Powhcr85NT5+er3+oViapw==",
+      "dev": true,
+      "requires": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "@types/sinon-chai": {
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.12.tgz",
+      "integrity": "sha512-9y0Gflk3b0+NhQZ/oxGtaAJDvRywCa5sIyaVnounqLvmf93yBF4EgIRspePtkMs3Tr844nCclYMlcCNmLCvjuQ==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "*",
+        "@types/sinon": "*"
+      }
+    },
+    "@types/sinonjs__fake-timers": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
+      "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
+      "dev": true
+    },
+    "@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true
     },
     "@types/ws": {
       "version": "7.4.7",
@@ -10196,6 +10458,12 @@
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
       "dev": true
     },
+    "axe-core": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.0.tgz",
+      "integrity": "sha512-Mr2ZakwQ7XUAjp7pAwQWRhhK8mQQ6JAaNWSjmjxil0R8BPioMtQsTLOolGYkji1rcL++3dCqZA3zWqpT+9Ew6g==",
+      "dev": true
+    },
     "b4a": {
       "version": "1.6.6",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.6.tgz",
@@ -10384,6 +10652,15 @@
         "deep-eql": "^5.0.1",
         "loupe": "^3.1.0",
         "pathval": "^2.0.0"
+      }
+    },
+    "chai-a11y-axe": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/chai-a11y-axe/-/chai-a11y-axe-1.5.0.tgz",
+      "integrity": "sha512-V/Vg/zJDr9aIkaHJ2KQu7lGTQQm5ZOH4u1k5iTMvIXuSVlSuUo0jcSpSqf9wUn9zl6oQXa4e4E0cqH18KOgKlQ==",
+      "dev": true,
+      "requires": {
+        "axe-core": "^4.3.3"
       }
     },
     "chalk": {
@@ -12638,6 +12915,37 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "lit": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.2.0.tgz",
+      "integrity": "sha512-s6tI33Lf6VpDu7u4YqsSX78D28bYQulM+VAzsGch4fx2H0eLZnJsUBsPWmGYSGoKDNbjtRv02rio1o+UdPVwvw==",
+      "dev": true,
+      "requires": {
+        "@lit/reactive-element": "^2.0.4",
+        "lit-element": "^4.1.0",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "lit-element": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.1.0.tgz",
+      "integrity": "sha512-gSejRUQJuMQjV2Z59KAS/D4iElUhwKpIyJvZ9w+DIagIQjfJnhR20h2Q5ddpzXGS+fF0tMZ/xEYGMnKmaI/iww==",
+      "dev": true,
+      "requires": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0",
+        "@lit/reactive-element": "^2.0.4",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "lit-html": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.2.0.tgz",
+      "integrity": "sha512-pwT/HwoxqI9FggTrYVarkBKFN9MlTUpLrDHubTmW4SrkL3kkqW5gxwbxMMUnbbRHBC0WTZnYHcjDSCM559VyfA==",
+      "dev": true,
+      "requires": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "locate-path": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@babel/core": "7.24.4",
     "@babel/eslint-parser": "7.24.1",
     "@esm-bundle/chai": "4.3.4-fix.0",
+    "@open-wc/testing": "4.0.0",
     "@web/test-runner": "^0.18.2",
     "@web/test-runner-commands": "^0.9.0",
     "chai": "5.1.0",

--- a/test/tools/tags/tag-selector.test.js
+++ b/test/tools/tags/tag-selector.test.js
@@ -1,0 +1,125 @@
+/* global describe it */
+import { expect } from '@esm-bundle/chai';
+import { html, fixture } from '@open-wc/testing';
+
+const { default: DaTagSelector } = await import('../../../tools/tags/tag-selector.js');
+
+describe('Tag Selector Plugin Tests', () => {
+  it('Fetch tags', async () => {
+    const project = {
+      org: 'jmphlx',
+      repo: 'jmp-da',
+    };
+    const dts = new DaTagSelector();
+    dts.project = project;
+    dts.token = 'foobar';
+    dts.datasource = 'tools/tagbrowser/mytags.json';
+    dts.displayName = 'mytags';
+
+    const jsonData = {
+      total: 2,
+      limit: 2,
+      offset: 0,
+      data: [
+        {
+          Tag: 'jmp',
+        },
+        {
+          Tag: 'jmp-pro',
+        },
+      ],
+      ':type': 'sheet',
+    };
+
+    const fetchResp = {
+      json: async () => jsonData,
+    };
+
+    const savedFetch = window.fetch;
+    try {
+      window.fetch = async (url, opts) => {
+        if (url === 'https://admin.da.live/source/jmphlx/jmp-da/tools/tagbrowser/mytags.json'
+          && opts.headers.Authorization === 'Bearer foobar') {
+          return fetchResp;
+        }
+        return null;
+      };
+
+      const tags = await dts.fetchTags();
+      const tr = await fixture(html`<div>${tags}</div>`);
+      expect(tr.querySelector('h2').innerText).to.equal('↑ mytags');
+      expect(tr.querySelector('h2 span.up').innerText).to.equal('↑');
+
+      const items = tr.querySelectorAll('ul form li label');
+      expect(items.length).to.equal(2);
+
+      const values = [];
+      // eslint-disable-next-line no-restricted-syntax
+      for (const item of items) {
+        expect(item.innerText).to.equal(item.querySelector('input').value);
+        values.push(item.innerText);
+      }
+      expect(values).to.deep.equal(['jmp', 'jmp-pro']);
+    } finally {
+      window.fetch = savedFetch;
+    }
+  });
+
+  it('Fetch categories', async () => {
+    const project = {
+      org: 'da',
+      repo: 'live',
+    };
+    const dts = new DaTagSelector();
+    dts.project = project;
+    dts.datasource = 'tools/tagbrowser/mycategories.json';
+    dts.displayName = 'Categories';
+
+    const jsonData = {
+      total: 3,
+      limit: 3,
+      offset: 0,
+      data: [
+        {
+          Category: 'resourceType',
+        },
+        {
+          Category: 'capabilities',
+        },
+        {
+          Category: 'product',
+        },
+      ],
+      ':type': 'sheet',
+    };
+
+    const fetchResp = {
+      json: async () => jsonData,
+    };
+
+    const savedFetch = window.fetch;
+    try {
+      window.fetch = async (url) => {
+        if (url === 'https://admin.da.live/source/da/live/tools/tagbrowser/mycategories.json') {
+          return fetchResp;
+        }
+        return null;
+      };
+
+      const tags = await dts.fetchTags();
+      const tr = await fixture(html`<div>${tags}</div>`);
+      expect(tr.querySelector('h2').innerText).to.equal('Categories');
+
+      const items = tr.querySelectorAll('ul form li');
+      expect(items.length).to.equal(3);
+      const categories = [];
+      items.forEach((item) => {
+        categories.push(item.innerText);
+      });
+      categories.sort();
+      expect(categories).to.deep.equal(['capabilities', 'product', 'resourceType']);
+    } finally {
+      window.fetch = savedFetch;
+    }
+  });
+});

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,0 +1,12 @@
+{
+  "project": "DA Block Collection",
+  "plugins": [
+    {
+      "id": "jmptags",
+      "title": "JMPTags",
+      "environments": ["edit"],
+      "daLibrary": true,
+      "url": "https://da.live/plugin/bosschaert/da-aem-boilerplate/local/tools/tags"
+    }
+  ]
+}

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -6,7 +6,7 @@
       "title": "JMPTags",
       "environments": ["edit"],
       "daLibrary": true,
-      "url": "https://da.live/plugin/bosschaert/da-aem-boilerplate/local/tools/tags"
+      "url": "https://da.live/plugin/jmphlx/jmp-da/main/tools/tags"
     }
   ]
 }

--- a/tools/tags.html
+++ b/tools/tags.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>DA App SDK Sample</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <link rel="icon" href="data:,">
+    <!-- Import DA App SDK -->
+    <script src="https://da.live/nx/utils/sdk.js" type="module"></script>
+    <!-- Project App Logic -->
+    <script src="/tools/tags/tags.js" type="module"></script>
+
+    <link rel="stylesheet" type="text/css" href="/tools/tags/tags.css">
+  </head>
+  <body>
+    <div id="copy-status">Copied</div>
+  </body>
+</html>

--- a/tools/tags/tag-selector.css
+++ b/tools/tags/tag-selector.css
@@ -1,0 +1,36 @@
+:host > p {
+  margin: 0;
+}
+
+h2, li, p {
+  font-family: 'Adobe Clean', adobe-clean, 'Trebuchet MS', sans-serif;
+}
+
+h2 {
+  color: #676767;
+  font-size: 24px;
+  font-weight: 800;
+  margin: 4px;
+}
+
+ul {
+  list-style-type: none;
+}
+
+li, li * {
+  color: #4D7BFF;
+  cursor: pointer;
+}
+
+li input {
+  margin-right: 8px;
+  vertical-align: bottom;
+}
+
+span.up {
+  cursor: pointer;
+}
+
+em {
+  color: lightgrey;
+}

--- a/tools/tags/tag-selector.js
+++ b/tools/tags/tag-selector.js
@@ -1,0 +1,130 @@
+import { LitElement, html, until } from 'https://da.live/deps/lit/lit-all.min.js';
+import getSheet from 'https://da.live/blocks/shared/sheet.js';
+
+const sheet = await getSheet('/tools/tags/tag-selector.css');
+
+export default class DaTagSelector extends LitElement {
+  static properties = {
+    project: { type: String },
+    token: { type: String },
+    datasource: { type: String },
+    iscategory: { type: Boolean },
+    displayName: { type: String },
+    parent: { type: Object },
+  };
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.shadowRoot.adoptedStyleSheets = [sheet];
+  }
+
+  getTagURL() {
+    return `https://admin.da.live/source/${this.project.org}/${this.project.repo}/${this.datasource}`
+  }
+
+  tagClicked(e) {
+    if (this.iscategory) {
+      const tagtext = e.target.innerText;
+      const sel = document.querySelector('da-tag-selector');
+      if (sel) {
+        const ts = document.createElement('da-tag-selector');
+        ts.project = sel.project;
+        ts.token = sel.token;
+        ts.datasource = `tools/tagbrowser/${tagtext.toLowerCase()}.json`;
+        ts.displayName = tagtext;
+        ts.parent = sel;
+        sel.parentNode.appendChild(ts);
+        sel.parentNode.removeChild(sel);
+      };
+    } else {
+      const form = e.target.form;
+      if (form) {
+        const values = [];
+        for (const item of form.elements) {
+          if (item.checked) {
+            values.push(item.value);
+          }
+        }
+        const vl = values.join(', ');
+        navigator.clipboard.writeText(vl).then(function() {
+          const sd = document.querySelector('#copy-status');
+          sd.style.opacity = '1';
+        }, function(err) {
+          console.error('Async: Could not copy text: ', err);
+        });
+      }
+    }
+  }
+
+  upClicked() {
+    const sel = document.querySelector('da-tag-selector');
+    if (sel) {
+      if (sel.parent) {
+        const sd = document.querySelector('#copy-status');
+        sd.style.opacity = '0';
+
+        sel.parentNode.appendChild(sel.parent);
+        sel.parentNode.removeChild(sel);
+      }
+    }
+  }
+
+  cl(e) {
+    console.log('Clicked: ', e.target.value);
+  }
+
+  async fetchTags() {
+    const url = this.getTagURL();
+
+    const opts = {
+      headers: {
+        Authorization: `Bearer ${this.token}`
+      }
+    }
+    const resp = await fetch(url, opts);
+    const tagData = await resp.json();
+
+    const categories = new Map();
+    tagData.data.forEach((el) => {
+      const k = Object.keys(el)[0];
+      const v = Object.values(el)[0];
+      let vals = categories.get(k);
+      if (!vals) {
+        vals = [];
+        categories.set(k, vals);
+      }
+      vals.push(v);
+    });
+
+    const tagLists = [];
+    categories.forEach((v, k) => {
+      this.iscategory = k.toLowerCase() === 'category';
+      const uplink = this.iscategory
+        ? html``
+        : html`<span class="up" @click="${this.upClicked}">↑</span> `;
+
+      const li = this.iscategory
+        ? html`${v.map((tag) => html`<li @click="${this.tagClicked}">${tag}</li>`)}`
+        : html`${v.map((tag) => html`<li><label><input type="checkbox" value="${tag}" @click="${this.tagClicked}">${tag}</label></li>`)}`
+
+      const el = html`<h2>${uplink}${this.displayName}</h2>
+      <ul><form>
+        ${li}
+      </form></ul>`
+      tagLists.push(el);
+    });
+    return tagLists;
+  }
+
+  listTags() {
+    return html`${until(this.fetchTags(), html`<p><em>Fetching tags...</em></p>`)}`;
+  }
+
+  render() {
+    return html`
+      ${this.listTags()}
+    `;
+  }
+}
+
+customElements.define('da-tag-selector', DaTagSelector);

--- a/tools/tags/tag-selector.js
+++ b/tools/tags/tag-selector.js
@@ -19,7 +19,7 @@ export default class DaTagSelector extends LitElement {
   }
 
   getTagURL() {
-    return `https://admin.da.live/source/${this.project.org}/${this.project.repo}/${this.datasource}`
+    return `https://admin.da.live/source/${this.project.org}/${this.project.repo}/${this.datasource}`;
   }
 
   tagClicked(e) {
@@ -35,27 +35,31 @@ export default class DaTagSelector extends LitElement {
         ts.parent = sel;
         sel.parentNode.appendChild(ts);
         sel.parentNode.removeChild(sel);
-      };
+      }
     } else {
-      const form = e.target.form;
+      const { target: { form } } = e;
       if (form) {
         const values = [];
+
+        // eslint-disable-next-line no-restricted-syntax
         for (const item of form.elements) {
           if (item.checked) {
             values.push(item.value);
           }
         }
         const vl = values.join(', ');
-        navigator.clipboard.writeText(vl).then(function() {
+        navigator.clipboard.writeText(vl).then(() => {
           const sd = document.querySelector('#copy-status');
           sd.style.opacity = '1';
-        }, function(err) {
+        }, (err) => {
+          // eslint-disable-next-line no-console
           console.error('Async: Could not copy text: ', err);
         });
       }
     }
   }
 
+  // eslint-disable-next-line class-methods-use-this
   upClicked() {
     const sel = document.querySelector('da-tag-selector');
     if (sel) {
@@ -69,18 +73,14 @@ export default class DaTagSelector extends LitElement {
     }
   }
 
-  cl(e) {
-    console.log('Clicked: ', e.target.value);
-  }
-
   async fetchTags() {
     const url = this.getTagURL();
 
     const opts = {
       headers: {
-        Authorization: `Bearer ${this.token}`
-      }
-    }
+        Authorization: `Bearer ${this.token}`,
+      },
+    };
     const resp = await fetch(url, opts);
     const tagData = await resp.json();
 
@@ -105,12 +105,12 @@ export default class DaTagSelector extends LitElement {
 
       const li = this.iscategory
         ? html`${v.map((tag) => html`<li @click="${this.tagClicked}">${tag}</li>`)}`
-        : html`${v.map((tag) => html`<li><label><input type="checkbox" value="${tag}" @click="${this.tagClicked}">${tag}</label></li>`)}`
+        : html`${v.map((tag) => html`<li><label><input type="checkbox" value="${tag}" @click="${this.tagClicked}">${tag}</label></li>`)}`;
 
       const el = html`<h2>${uplink}${this.displayName}</h2>
       <ul><form>
         ${li}
-      </form></ul>`
+      </form></ul>`;
       tagLists.push(el);
     });
     return tagLists;

--- a/tools/tags/tags.css
+++ b/tools/tags/tags.css
@@ -1,0 +1,14 @@
+div {
+  font-family: 'Adobe Clean', adobe-clean, 'Trebuchet MS', sans-serif;
+  font-size: 16px;
+  font-weight: 800;
+}
+
+#copy-status {
+  color: green;
+  position: absolute;
+  top: 0;
+  right: 10px;
+  opacity: 0;
+  transition: opacity 1s;
+}

--- a/tools/tags/tags.js
+++ b/tools/tags/tags.js
@@ -1,0 +1,16 @@
+// Import SDK
+import DA_SDK from 'https://da.live/nx/utils/sdk.js';
+
+// Import Web Component
+import './tag-selector.js';
+
+(async function init() {
+  const { project, token } = await DA_SDK;
+  const tagSelector = document.createElement('da-tag-selector');
+  tagSelector.project = project;
+  tagSelector.token = token;
+  tagSelector.datasource = 'tools/tagbrowser/tag-categories.json';
+  tagSelector.iscategory = true;
+  tagSelector.displayName = 'Categories';
+  document.body.append(tagSelector);
+}());


### PR DESCRIPTION
Initial implementation of a JMP-specific tag selection plugin.

To configure, create a sheet named `tools/tagbrowser/tag-categories`, which lists the categories categories, e.g.

|   | A |
| ------------- | ------------- |
| 1 | Category  |
| 2 | resourceType  |
| 3 | capabilities |
| 4 | product |
| 5 | resourceOptions |
| 6 | |

Then, for each category define a sheet with a matching name, e.g. `tools/tagbrowser/resourceType` with the tags:

| | A | 
| --- | --- |
| 1 | Tag |
| 2 | Article |
| 3 | Event |
| 4 | Customer Story |

The Tags are then selectable from the JMPTags Library plugin and copied to the clipboard. They can then be pasted into the document.

Note, sub-categories are also supported.