### PR TITLE
Symbolic label for tags enabled by default

### DIFF
--- a/tools/tags/tag-selector.js
+++ b/tools/tags/tag-selector.js
@@ -84,8 +84,8 @@ export default class DaTagSelector extends LitElement {
     const resp = await fetch(url, opts);
     const tagData = await resp.json();
 
-    let sheetType;
-    let langKey;
+    let sheetType = 'Tag';
+    let langKey = 'Tag';
     let selection = 'Multiple';
     const md = tagData.metadata;
     if (md) {


### PR DESCRIPTION
Tag plugin: support a non-language tag label by default, without the need for configuration in the metadata sheet.