### PR TITLE
Add datepicker and migrate tag selector to new SDK API

### DIFF
--- a/test/tools/datepicker/datepicker.test.js
+++ b/test/tools/datepicker/datepicker.test.js
@@ -1,0 +1,116 @@
+/* global describe it */
+import { expect } from '@esm-bundle/chai';
+import { html, fixture } from '@open-wc/testing';
+import DaTagSelector from '../../../tools/tags/tag-selector.js';
+
+const dp = await import('../../../tools/datepicker/datepicker.js');
+
+describe('Tag Selector Plugin Tests', () => {
+  it('Initialize Time Zones', async () => {
+    const children = [];
+    const mockSelect = {
+      appendChild: (child) => {
+        if (child.name === 'option') {
+          children.push(child.textContent);
+        }
+      },
+    };
+
+    const mockDoc = {
+      getElementById: (id) => (id === 'time-zone' ? mockSelect : null),
+      createElement: (name) => (name === 'option' ? { name: 'option' } : null),
+    };
+
+    dp.initTimeZones(mockDoc);
+    expect(children.length).to.be.greaterThan(0);
+    expect(children).to.deep.include('(GMT+00:00) Azores Summer Time');
+    expect(children).to.deep.include('(GMT+02:00) GMT+02:00');
+  });
+
+  it('Use button clicked with date', () => {
+    const event = {
+      preventDefault: () => {},
+    };
+
+    const textSent = [];
+    const actions = {
+      closeLibrary: () => {},
+      sendText: (t) => textSent.push(t),
+    };
+
+    const datefield = {
+      value: '2029-12-15',
+    };
+
+    const form = {
+      reportValidity: () => true,
+    };
+    const mockDoc = {
+      querySelector: (selector) => {
+        switch (selector) {
+          case 'form#picker':
+            return form;
+          case 'form#typeselect input[name="date-picker"]:checked':
+            return { value: 'date' };
+          case 'form#picker input[type=date]':
+            return datefield;
+          default:
+            return null;
+        }
+      },
+    };
+    dp.useButtonClicked(event, actions, mockDoc);
+    expect(textSent).to.deep.equal(['2029-12-15']);
+  });
+
+  it('Use button clicked with date and time', () => {
+    const event = {
+      preventDefault: () => {},
+    };
+
+    const textSent = [];
+    const actions = {
+      closeLibrary: () => {},
+      sendText: (t) => textSent.push(t),
+    };
+
+    const datefield = {
+      value: '2021-07-01',
+    };
+    const timefield = {
+      value: '15:23',
+    };
+    const tzfield = {
+      value: '+12:00',
+    };
+
+    const reportValidity = [];
+    const form = {
+      reportValidity: () => {
+        reportValidity.push('called');
+        return true;
+      },
+    };
+    const mockDoc = {
+      querySelector: (selector) => {
+        switch (selector) {
+          case 'form#picker':
+            return form;
+          case 'form#typeselect input[name="date-picker"]:checked':
+            return { value: 'datetime' };
+          case 'form#picker input[type=date]':
+            return datefield;
+          case 'form#picker input[type=time]':
+            return timefield;
+          case 'form#picker select#time-zone':
+            return tzfield;
+          default:
+            return null;
+        }
+      },
+    };
+    dp.useButtonClicked(event, actions, mockDoc);
+    expect(textSent).to.deep.equal(['2021-07-01 03:23Z']);
+    expect(reportValidity).to.deep.equal(['called']);
+  });
+});

--- a/test/tools/tags/tag-selector.test.js
+++ b/test/tools/tags/tag-selector.test.js
@@ -50,7 +50,7 @@ describe('Tag Selector Plugin Tests', () => {
       expect(tr.querySelector('h2').innerText).to.equal('↑ mytags');
       expect(tr.querySelector('h2 span.up').innerText).to.equal('↑');
 
-      const items = tr.querySelectorAll('ul form li label');
+      const items = tr.querySelectorAll('form ul li label');
       expect(items.length).to.equal(2);
 
       const values = [];
@@ -112,7 +112,7 @@ describe('Tag Selector Plugin Tests', () => {
       const tr = await fixture(html`<div>${tags}</div>`);
       expect(tr.querySelector('h2').innerText).to.equal('Categories');
 
-      const items = tr.querySelectorAll('ul form li');
+      const items = tr.querySelectorAll('form ul li');
       expect(items.length).to.equal(3);
       const categories = [];
       items.forEach((item) => {
@@ -186,7 +186,7 @@ describe('Tag Selector Plugin Tests', () => {
 
     const savedFetch = window.fetch;
     try {
-      window.fetch = async (url, opts) => {
+      window.fetch = async (url) => {
         if (url === 'https://admin.da.live/source/jmphlx/jmp-da/tools/tagbrowser/mytags.json') {
           return fetchResp;
         }
@@ -198,7 +198,7 @@ describe('Tag Selector Plugin Tests', () => {
       expect(tr.querySelector('h2').innerText).to.equal('↑ mytags');
       expect(tr.querySelector('h2 span.up').innerText).to.equal('↑');
 
-      const items = tr.querySelectorAll('ul form li label');
+      const items = tr.querySelectorAll('form ul li label');
       expect(items.length).to.equal(2);
 
       const values = [];

--- a/tools/datepicker.html
+++ b/tools/datepicker.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Date Picker</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <link rel="icon" href="data:,">
+    <!-- Import DA App SDK -->
+    <script src="https://da.live/nx/utils/sdk.js" type="module"></script>
+    <!-- Project App Logic -->
+    <script src="/tools/datepicker/datepicker.js" type="module"></script>
+
+    <link rel="stylesheet" type="text/css" href="/tools/datepicker/datepicker.css">
+  </head>
+  <body>
+    <form id="typeselect">
+      <label><input type="radio" name="date-picker" value="date">Date</label>
+      <label><input type="radio" name="date-picker" value="datetime" checked>Date + Time</label>
+      <!--
+      <label><input type="radio" name="date-picker" value="time">Time</label>
+      -->
+    </form>
+    <form id="picker">
+      <div id="date-time">
+        <input type="date" id="date-picker" name="date-picker" required>
+        <input type="time" id="time-picker" name="time-picker" required>
+      </div>
+      <select name="time-picker" id="time-zone"></select>
+      <button id="use">Insert</button>
+    </form>
+  </body>
+</html>

--- a/tools/datepicker/datepicker.css
+++ b/tools/datepicker/datepicker.css
@@ -1,0 +1,28 @@
+form#picker {
+  display: flex;
+  flex-direction: column;
+  margin: 10px 0;
+}
+
+form#picker > * {
+  margin: 4px;
+}
+
+button#use {
+  background-color: dodgerblue;
+  border: none;
+  color: white;
+  padding: 10px;
+  font-size: 16px;
+  cursor: pointer;
+}
+
+input, label, select, button {
+  font-family: 'Adobe Clean', adobe-clean, 'Trebuchet MS', sans-serif;
+  font-size: 18px;
+  font-weight: 400;
+}
+
+#time-zone {
+  width: 100% - 8px;
+}

--- a/tools/datepicker/datepicker.js
+++ b/tools/datepicker/datepicker.js
@@ -1,0 +1,116 @@
+import DA_SDK from 'https://da.live/nx/utils/sdk.js';
+
+export function initTimeZones(doc = document) {
+  const select = doc.getElementById('time-zone');
+
+  let defTZ = '';
+  const curTZ = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const timezonesWithoffsets = Intl.supportedValuesOf('timeZone').map((timeZone) => {
+    let offset = new Intl.DateTimeFormat('en', { timeZone, timeZoneName: 'longOffset' })
+      .formatToParts().find((part) => part.type === 'timeZoneName').value;
+    if (offset === 'GMT') {
+      offset = 'GMT+00:00';
+    }
+    const timeZoneAbbrivation = new Intl.DateTimeFormat('en', { timeZone, timeZoneName: 'long' })
+      .formatToParts().find((part) => part.type === 'timeZoneName').value;
+    const tz = `(${offset}) ${timeZoneAbbrivation}`;
+    if (timeZone === curTZ) {
+      defTZ = tz;
+    }
+    return tz;
+  });
+  const tzSet = Array.from(new Set(timezonesWithoffsets)).sort();
+
+  tzSet.forEach((tz) => {
+    const opt = doc.createElement('option');
+    opt.textContent = tz;
+
+    const delta = tz.substring(4, tz.indexOf(')'));
+    opt.value = delta;
+
+    if (tz === defTZ) {
+      opt.selected = true;
+    }
+
+    select.appendChild(opt);
+  });
+}
+
+function typeChange(e) {
+  let hasDate = false;
+  let hasTime = false;
+  switch (e.target.value) {
+    case 'date':
+      hasDate = true;
+      break;
+    case 'time':
+      hasTime = true;
+      break;
+    default:
+      hasDate = true;
+      hasTime = true;
+      break;
+  }
+  document.querySelectorAll('form#picker input[type=date]').forEach((date) => {
+    date.hidden = !hasDate;
+    date.required = hasDate;
+  });
+  document.querySelectorAll('form#picker [name=time-picker]').forEach((time) => {
+    time.hidden = !hasTime;
+    time.required = hasTime;
+  });
+}
+
+export function useButtonClicked(e, actions, doc = document) {
+  e.preventDefault();
+
+  const form = doc.querySelector('form#picker');
+  if (!form.reportValidity()) {
+    return;
+  }
+
+  const inputType = doc.querySelector('form#typeselect input[name="date-picker"]:checked').value;
+  let seldate = '';
+  if (inputType.includes('date')) {
+    seldate = doc.querySelector('form#picker input[type=date]').value;
+  }
+
+  let seltime = '';
+  let seltz = '';
+  if (inputType.includes('time')) {
+    seltime = doc.querySelector('form#picker input[type=time]').value;
+    seltz = doc.querySelector('form#picker select#time-zone').value;
+  } else {
+    actions.sendText(seldate);
+    actions.closeLibrary();
+    return;
+  }
+
+  const d = new Date(`${seldate}T${seltime}${seltz}`);
+
+  const result = d.toISOString();
+  const cIdx = result.lastIndexOf(':');
+  const result2 = result.substring(0, cIdx);
+  const result3 = result2.replace('T', ' ');
+  const result4 = `${result3}Z`;
+
+  actions.sendText(result4);
+  actions.closeLibrary();
+}
+
+function initControls(actions) {
+  document.querySelectorAll('form#typeselect input[type=radio]').forEach((radio) => {
+    radio.addEventListener('change', typeChange);
+  });
+
+  document.querySelectorAll('button#use').forEach((button) => {
+    button.onclick = (e) => useButtonClicked(e, actions);
+  });
+}
+
+(async function init() {
+  const { actions } = await DA_SDK;
+
+  initControls(actions);
+  initTimeZones();
+}());

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -3,10 +3,15 @@
   "plugins": [
     {
       "id": "jmptags",
-      "title": "JMPTags",
-      "environments": ["edit"],
-      "daLibrary": true,
-      "url": "https://da.live/plugin/jmphlx/jmp-da/main/tools/tags"
+      "title": "JMP Tags",
+      "environments": ["da-edit"],
+      "path": "/tools/tags.html"
+    },
+    {
+      "id": "datepicker",
+      "title": "Date Picker",
+      "environments": ["da-edit"],
+      "path": "/tools/datepicker.html"
     }
   ]
 }

--- a/tools/tags.html
+++ b/tools/tags.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>DA App SDK Sample</title>
+    <title>Tag Picker</title>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <link rel="icon" href="data:,">
     <!-- Import DA App SDK -->
@@ -12,6 +12,5 @@
     <link rel="stylesheet" type="text/css" href="/tools/tags/tags.css">
   </head>
   <body>
-    <div id="copy-status">Copied</div>
   </body>
 </html>

--- a/tools/tags/tag-selector.css
+++ b/tools/tags/tag-selector.css
@@ -1,5 +1,6 @@
-:host > p {
-  margin: 0;
+div {
+  display: flex;
+  flex-direction: column;
 }
 
 h2, li, p {
@@ -27,10 +28,24 @@ li input {
   vertical-align: bottom;
 }
 
+li input[type="radio"] {
+  vertical-align: baseline;
+}
+
 span.up {
   cursor: pointer;
 }
 
 em {
   color: lightgrey;
+}
+
+button#use {
+  background-color: dodgerblue;
+  border: none;
+  color: white;
+  padding: 10px;
+  font-size: 16px;
+  cursor: pointer;
+  width: 100%;
 }

--- a/tools/tags/tag-selector.js
+++ b/tools/tags/tag-selector.js
@@ -7,6 +7,7 @@ export default class DaTagSelector extends LitElement {
   static properties = {
     project: { type: String },
     token: { type: String },
+    actions: { type: Object },
     datasource: { type: String },
     iscategory: { type: Boolean },
     displayName: { type: String },
@@ -30,13 +31,32 @@ export default class DaTagSelector extends LitElement {
         const ts = document.createElement('da-tag-selector');
         ts.project = sel.project;
         ts.token = sel.token;
+        ts.actions = sel.actions;
         ts.datasource = `tools/tagbrowser/${tagtext.toLowerCase()}.json`;
         ts.displayName = tagtext;
         ts.parent = sel;
         sel.parentNode.appendChild(ts);
         sel.parentNode.removeChild(sel);
       }
-    } else {
+    }
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  upClicked() {
+    const sel = document.querySelector('da-tag-selector');
+    if (sel) {
+      if (sel.parent) {
+        sel.parentNode.appendChild(sel.parent);
+        sel.parentNode.removeChild(sel);
+      }
+    }
+  }
+
+  useButtonClicked(e) {
+    e.preventDefault();
+
+    document.querySelector('da-tag-selector');
+    if (!this.iscategory) {
       const { target: { form } } = e;
       if (form) {
         const values = [];
@@ -47,28 +67,9 @@ export default class DaTagSelector extends LitElement {
             values.push(item.value);
           }
         }
+
         const vl = values.join(', ');
-        navigator.clipboard.writeText(vl).then(() => {
-          const sd = document.querySelector('#copy-status');
-          sd.style.opacity = '1';
-        }, (err) => {
-          // eslint-disable-next-line no-console
-          console.error('Async: Could not copy text: ', err);
-        });
-      }
-    }
-  }
-
-  // eslint-disable-next-line class-methods-use-this
-  upClicked() {
-    const sel = document.querySelector('da-tag-selector');
-    if (sel) {
-      if (sel.parent) {
-        const sd = document.querySelector('#copy-status');
-        sd.style.opacity = '0';
-
-        sel.parentNode.appendChild(sel.parent);
-        sel.parentNode.removeChild(sel);
+        this.actions.sendText(vl);
       }
     }
   }
@@ -129,7 +130,10 @@ export default class DaTagSelector extends LitElement {
     const uplink = this.iscategory
       ? html``
       : html`<span class="up" @click="${this.upClicked}">↑</span> `;
-    return html`<h2>${uplink}${this.displayName}</h2><ul><form>${tagLists}</form></ul>`;
+    const usebtn = this.iscategory
+      ? html``
+      : html`<button @click="${this.useButtonClicked}" id="use">Insert</button>`;
+    return html`<div><h2>${uplink}${this.displayName}</h2><form><ul>${tagLists}</ul>${usebtn}</form><div>`;
   }
 
   listTags() {

--- a/tools/tags/tags.css
+++ b/tools/tags/tags.css
@@ -3,12 +3,3 @@ div {
   font-size: 16px;
   font-weight: 800;
 }
-
-#copy-status {
-  color: green;
-  position: absolute;
-  top: 0;
-  right: 10px;
-  opacity: 0;
-  transition: opacity 1s;
-}

--- a/tools/tags/tags.js
+++ b/tools/tags/tags.js
@@ -5,10 +5,11 @@ import DA_SDK from 'https://da.live/nx/utils/sdk.js';
 import './tag-selector.js';
 
 (async function init() {
-  const { project, token } = await DA_SDK;
+  const { project, token, actions } = await DA_SDK;
   const tagSelector = document.createElement('da-tag-selector');
   tagSelector.project = project;
   tagSelector.token = token;
+  tagSelector.actions = actions;
   tagSelector.datasource = 'tools/tagbrowser/tag-categories.json';
   tagSelector.iscategory = true;
   tagSelector.displayName = 'Categories';


### PR DESCRIPTION
Add a new date and date+time picker.
Update the tag selector to use the new plugin SDK.

Both can now insert text directly into the document via the new `Insert` button.