### PR TITLE
AEM-264: Update listgroup and fixed listgroup to use displayDescription

### DIFF
--- a/blocks/listgroup-fixed/listgroup-fixed.js
+++ b/blocks/listgroup-fixed/listgroup-fixed.js
@@ -49,7 +49,7 @@ export default async function decorate(block) {
     if (optionsObject.images === undefined || optionsObject.images.toLowerCase() !== 'off') {
       htmlOutput += `<span class="cmp-image image"><img src="${getMetadata('og:image', doc)}"/></span>`;
     }
-    htmlOutput += `<span class="abstract">${getMetadata('og:description', doc)}</span>`;
+    htmlOutput += `<span class="abstract">${getMetadata('displaydescription', doc)}</span>`;
 
     cardLink.innerHTML = htmlOutput;
 

--- a/blocks/listgroup/listgroup.js
+++ b/blocks/listgroup/listgroup.js
@@ -84,7 +84,7 @@ export default async function decorate(block) {
     if (optionsObject.images === undefined || optionsObject.images.toLowerCase() !== 'off') {
       htmlOutput += `<span class="cmp-image image"><img src="${item.image}"/></span>`;
     }
-    htmlOutput += `<span class="abstract">${item.description}</span>`;
+    htmlOutput += `<span class="abstract">${item.displayDescription}</span>`;
     cardLink.innerHTML = htmlOutput;
 
     listItem.append(cardLink);


### PR DESCRIPTION
[AEM-264](https://jmpdiscovery.atlassian.net/browse/AEM-264): Update listgroup and fixed listgroup to use displayDescription

Test URLs:
- Before: https://main--jmp-da--jmphlx.hlx.live/en/sandbox/laurel/listgroups/fixed
- After: https://aem-264--jmp-da--jmphlx.hlx.live/en/sandbox/laurel/listgroups/fixed

URL for testing:

- Listgroup: https://aem-264--jmp-da--jmphlx.hlx.page/en/sandbox/laurel/listgroups/resources
- Fixed Listgroup: https://aem-264--jmp-da--jmphlx.hlx.live/en/sandbox/laurel/listgroups/fixed
