### PR TITLE
Add preview loader in

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -17,9 +17,9 @@ import {
 
 const LCP_BLOCKS = []; // add your LCP blocks to the list
 
-(async function daPreview() {
-  const { searchParams } = new URL(window.location.href);
-  if (searchParams.get('dapreview') === 'on') import('./dapreview.js');
+(async function loadDa() {
+  if (!new URL(window.location.href).searchParams.get('dapreview')) return;
+  import('https://da.live/scripts/dapreview.js').then(({ default: daPreview }) => daPreview(loadPage));
 }());
 
 /**

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -17,6 +17,11 @@ import {
 
 const LCP_BLOCKS = []; // add your LCP blocks to the list
 
+(async function daPreview() {
+  const { searchParams } = new URL(window.location.href);
+  if (searchParams.get('dapreview') === 'on') import('./dapreview.js');
+}());
+
 /**
  * OUT OF THE BOX code that impacts our hero blocks.
  * To be removed if no other issues found.


### PR DESCRIPTION
I noticed that the live DA preview wasn't functioning, and this piece of code that should be in the `scripts.js` was missing.

This should contribute to making the live preview working again.