### PR TITLE
Add ability to NOT include header and footer

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -26,6 +26,7 @@ import { createTag } from './helper.js';
 }());
 
 let isSKPPage = false;
+let includeDelayedScript = true;
 
 const defaultMetaImage = `${window.location.origin}/icons/jmp-com-share.jpg`;
 
@@ -449,17 +450,25 @@ async function loadLazy(doc) {
   const element = hash ? doc.getElementById(hash.substring(1)) : false;
   if (hash && element) element.scrollIntoView();
 
-  // If this is a SKP page, use the SKP header (custom and reduces js).
-  if (isSKPPage) {
-    const headerBlock = buildBlock('header-skp', '');
-    doc.querySelector('header').append(headerBlock);
-    decorateBlock(headerBlock);
-    loadBlock(headerBlock);
-  } else {
-    loadHeader(doc.querySelector('header'));
+  const noHeader = getMetadata('nav') === 'noHeader';
+  const noFooter = getMetadata('footer') === 'noFooter';
+  includeDelayedScript = !noHeader && !noFooter;
+
+  if (!noHeader) {
+    // If this is a SKP page, use the SKP header (custom and reduces js).
+    if (isSKPPage) {
+      const headerBlock = buildBlock('header-skp', '');
+      doc.querySelector('header').append(headerBlock);
+      decorateBlock(headerBlock);
+      loadBlock(headerBlock);
+    } else {
+      loadHeader(doc.querySelector('header'));
+    }
   }
 
-  loadFooter(doc.querySelector('footer'));
+  if (!noFooter) {
+    loadFooter(doc.querySelector('footer'));
+  }
 
   loadCSS(`${window.hlx.codeBasePath}/styles/lazy-styles.css`);
   loadFonts();
@@ -478,7 +487,9 @@ function loadDelayed() {
 async function loadPage() {
   await loadEager(document);
   await loadLazy(document);
-  loadDelayed();
+  if (includeDelayedScript) {
+    loadDelayed();
+  }
 }
 
 loadPage();


### PR DESCRIPTION
Add ability to no include the header and footer, but setting nav as "noHeader" and footer as "noFooter". Additionally, if both are not included, don't bring in the delayed.js

[AEM-487](https://jmpdiscovery.atlassian.net/browse/AEM-487)

Test URLs:
- Before: https://main--jmp-da--jmphlx.hlx.live/en/early-adopter/my-jmp-iframe
- After: https://aem-487--jmp-da--jmphlx.hlx.live/en/early-adopter/my-jmp-iframe

URL for testing:

- https://aem-487--jmp-da--jmphlx.hlx.page/en/early-adopter/my-jmp-iframe
