### PR TITLE
Fix listgroup-fixed to use images relative to current origin

### DIFF
--- a/blocks/listgroup-fixed/listgroup-fixed.js
+++ b/blocks/listgroup-fixed/listgroup-fixed.js
@@ -24,6 +24,19 @@ function getMetaValue(prop, doc) {
   } else {
     val = getMetadata(prop.toLowerCase(), doc);
   }
+
+  // Make images relative to the domain,
+  // and not the meta image which is
+  // relative to the production origin.
+  if (prop === 'image' && val) {
+    try {
+      const { pathname, search } = new URL(val);
+    return `${pathname}${search}`;
+    } catch {
+      return val;
+    }
+  }
+
   return val;
 }
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--jmp-da--jmphlx.hlx.live/
- After: https://branch--jmp-da--jmphlx.hlx.live/

URL for testing:

- https://{branch}--jmp-da--jmphlx.hlx.page/
