### PR TITLE
caption controls

### DIFF
--- a/blocks/embed/embed.js
+++ b/blocks/embed/embed.js
@@ -59,6 +59,13 @@ const embedTwitter = (url) => {
 // vidyard videos
 export const embedVidyard = (url) => {
   const video = url.pathname.split('/').pop(); // breaks out UUID of vidyard URL
+  console.log(video);
+  console.log(url.search);
+  console.log("asdkljasfdjlk;asj;klda")
+
+  const query = url.search;
+  const lang = query.slice(-2);
+  console.log(lang);
 
   loadScript('https://play.vidyard.com/embed/v4.js');
 
@@ -73,6 +80,7 @@ export const embedVidyard = (url) => {
         container: document.querySelector('div.embed-vidyard'),
         autoplay,
         type: 'inline',
+        cc: lang,
       });
     };
     return null;
@@ -86,7 +94,8 @@ export const embedVidyard = (url) => {
       data-uuid="${video}"
       data-v="4"
       data-autoplay=${autoplay}
-      data-type="inline"/>
+      data-type="inline"
+      data-cc="${lang}"/>
     </div>`;
   return embedHTML;
 };


### PR DESCRIPTION
adds functionality for dictating what language the subtitles of a video will be in using the query parameter of the url. adding ?cc=[language code] at the end of the embed url will pass the given language code along to the embed code, enabling captions in that language. This code currently appears to have the knock-on effect of default enabling captions even when no query is passed, LMK if this is not desired behavior and I'll implement a check of the query.


Test URLs:
- Before: https://main--jmp-da--jmphlx.hlx.live/
- After: https://Vidyard-caption-controls--jmp-da--jmphlx.hlx.live/

URL for testing:

- https://Vidyard-caption-controls--jmp-da--jmphlx.hlx.page/ko/online-statistics-course
