### PR TITLE
Language Switcher for Traditional Chinese

### DIFF
--- a/scripts/jmp.js
+++ b/scripts/jmp.js
@@ -360,8 +360,7 @@ function pageFilterByFolder(pageSelection, folderPath) {
  */
 async function getLangMenuPageUrl(languagePage) {
   const languageDirectory = languagePage.split('/')[1];
-
-  const currPage = pagePath.replace(/\/(.*?)\w+/, '');
+  const currPage = pagePath.replace(/\/(.*?)(?:\/)/, '/');
   const languageCurrPage = `/${languageDirectory}${currPage}`;
 
   try {


### PR DESCRIPTION
Change page language switcher regex so it works for both 2 digit and hypened languages like zh-hant

Test URLs:
- Before: https://main--jmp-da--jmphlx.hlx.live/zh-hant/software/predictive-analytics-software
- After: https://aem-751--jmp-da--jmphlx.hlx.live/zh-hant/software/predictive-analytics-software

URL for testing:

- https://aem-751--jmp-da--jmphlx.hlx.live/zh-hant/software/predictive-analytics-software
