### PR TITLE
AEM-781 - Changing "last_action" --> "last_action__c"

### DIFF
--- a/blocks/hubspot/hubspot.js
+++ b/blocks/hubspot/hubspot.js
@@ -41,7 +41,7 @@ const embedHubspot = (config) => {
         redirectUrl: '${redirect}',
         sfdcCampaignId: '${sfdcCampaignId}',
         onFormReady($form) {
-          const hiddenField2 = $form.find('input[name="last_action"]');
+          const hiddenField2 = $form.find('input[name="last_action__c"]');
           const newValue2 = "${config.lastAction}"; // The value you want to append
           hiddenField2.val(newValue2).change();
   


### PR DESCRIPTION
This is a fix to the last_action parameter, so that the hidden field in hubspot forms comes through as "last_action__c" instead of "last_action" on its way from Hubspot -> Salesforce

Test URLs:
- Before: https://main--jmp-da--jmphlx.aem.page/en/events/europe/live-webinars/time-to-innovate/2025/leadsource-test
- After: https://aem-781--jmp-da--jmphlx.aem.page/en/events/europe/live-webinars/time-to-innovate/2025/leadsource-test


