### PR TITLE
AEM-824: Translate emptyResultsMessage for all listgroups

### DIFF
--- a/blocks/listgroup-asset/listgroup-asset.js
+++ b/blocks/listgroup-asset/listgroup-asset.js
@@ -5,13 +5,15 @@ import {
   getJsonFromUrl,
 } from '../../scripts/jmp.js';
 
+import { getEmptyResultsMessage } from '../../scripts/listgroup.js'; 
+
 /**
  * Assume sort by title alphabetically.
  * Assume ascending order (A-Z) unless otherwise specified.
  */
 function sortAssetList(assetList, sortOrder) {
   const sortedList = assetList;
-  sortedList.sort((a, b) => {
+  sortedList?.sort((a, b) => {
     if (sortOrder !== undefined && sortOrder === 'descending') {
       return (a.title < b.title ? 1 : -1);
     }
@@ -29,7 +31,7 @@ function buildAssetItems(matching, config) {
   }
 
   const emptyResultsMessage = config.emptyResultsMessage;
-  if ((pageSelection === undefined || pageSelection.length === 0)
+  if ((pageSelection === null || pageSelection === undefined || pageSelection.length === 0)
       && emptyResultsMessage !== undefined) {
     const emptyResultsDiv = document.createElement('div');
     emptyResultsDiv.classList = 'no-results';
@@ -63,6 +65,7 @@ function buildAssetItems(matching, config) {
 export default async function decorate(block) {
   const config = getBlockConfig(block);
   block.textContent = '';
+  config.emptyResultsMessage = await getEmptyResultsMessage(config.emptyResultsMessage);
   const folderPath = config.folderPath;
   const assetServiceURL = 'https://www.jmp.com/services/damservlet';
 

--- a/blocks/listgroup-asset/listgroup-asset.js
+++ b/blocks/listgroup-asset/listgroup-asset.js
@@ -5,7 +5,7 @@ import {
   getJsonFromUrl,
 } from '../../scripts/jmp.js';
 
-import { getEmptyResultsMessage } from '../../scripts/listgroup.js'; 
+import { getEmptyResultsMessage } from '../../scripts/listgroup.js';
 
 /**
  * Assume sort by title alphabetically.

--- a/blocks/listgroup-custom/listgroup-custom.js
+++ b/blocks/listgroup-custom/listgroup-custom.js
@@ -16,6 +16,8 @@ import {
   writeImagePropertyInList,
 } from '../../scripts/jmp.js';
 
+import { getEmptyResultsMessage } from '../../scripts/listgroup.js';
+
 import { loadScript } from '../../scripts/aem.js';
 import { createTag } from '../../scripts/helper.js';
 
@@ -60,23 +62,6 @@ function processDate(dateProperty, prop, item) {
     span = `<span class="${prop}">${item[prop]}</span>`;
   }
   return span;
-}
-
-async function getEmptyResultsMessage(emptyResultString) {
-  if (!emptyResultString) {
-    return undefined;
-  }
-
-  if (emptyResultString.includes('.json')) {
-    const pageLanguage = getLanguage();
-    const data = await getJsonFromUrl(emptyResultString);
-    const { data: translations } = data[pageLanguage];
-    console.log(translations[0]);
-    return translations[0].emptyResultsMessage;
-  } else {
-    // use the string as the empty results message. It won't translate.
-    return emptyResultString;
-  }
 }
 
 async function getTagTranslations() {

--- a/blocks/listgroup-custom/listgroup-custom.js
+++ b/blocks/listgroup-custom/listgroup-custom.js
@@ -62,6 +62,23 @@ function processDate(dateProperty, prop, item) {
   return span;
 }
 
+async function getEmptyResultsMessage(emptyResultString) {
+  if (!emptyResultString) {
+    return undefined;
+  }
+
+  if (emptyResultString.includes('.json')) {
+    const pageLanguage = getLanguage();
+    const data = await getJsonFromUrl(emptyResultString);
+    const { data: translations } = data[pageLanguage];
+    console.log(translations[0]);
+    return translations[0].emptyResultsMessage;
+  } else {
+    // use the string as the empty results message. It won't translate.
+    return emptyResultString;
+  }
+}
+
 async function getTagTranslations() {
   const pageLanguage = getLanguage();
   window.tagtranslations = window.tagtranslations || await getJsonFromUrl(`${tagTranslationsBaseURL}.${pageLanguage}`);
@@ -421,7 +438,8 @@ function buildListItems(block, matching, tabDictionary, config) {
     const emptyResultsDiv = document.createElement('div');
     emptyResultsDiv.classList = 'listOfItems no-results';
     emptyResultsDiv.innerHTML = `<span>${emptyResultsMessage}</span>`;
-    return emptyResultsDiv;
+    block.append(emptyResultsDiv);
+    return;
   }
 
   const listItems = writeAsOneGroup(pageSelection, config);
@@ -552,6 +570,7 @@ export default async function decorate(block) {
   const tabsArray = config.tabs;
   useTabs = tabProperty && tabsArray;
   useFilter = filterBy;
+  config.emptyResultsMessage = await getEmptyResultsMessage(config.emptyResultsMessage);
 
   let matching = [];
   allPages.forEach((page) => {

--- a/blocks/listgroup-events-tabs/listgroup-events-tabs.js
+++ b/blocks/listgroup-events-tabs/listgroup-events-tabs.js
@@ -13,6 +13,8 @@ import {
   pageOrFilter,
 } from '../../scripts/jmp.js';
 
+import { getEmptyResultsMessage } from '../../scripts/listgroup.js';
+
 /*
  * Apply where a property is not empty.
  */
@@ -68,7 +70,8 @@ export default async function decorate(block) {
   const optionsObject = getBlockPropertiesList(block, 'options');
   const tabs = getBlockPropertiesList(block, 'tabs');
   const startingFolder = getBlockProperty(block, 'startingFolder');
-  const emptyResultsMessage = getBlockProperty(block, 'emptyResultsMessage');
+  const emptyResultsMessageConfig = getBlockProperty(block, 'emptyResultsMessage');
+  const emptyResultsMessage = await getEmptyResultsMessage(emptyResultsMessageConfig);
   const filterOptions = getListFilterOptions(block, propertyNames);
 
   // If startingFolder is not null, then apply page location filter FIRST.

--- a/blocks/listgroup-events/listgroup-events.js
+++ b/blocks/listgroup-events/listgroup-events.js
@@ -13,6 +13,8 @@ import {
   pageOrFilter,
 } from '../../scripts/jmp.js';
 
+import { getEmptyResultsMessage } from '../../scripts/listgroup.js';
+
 export default async function decorate(block) {
   const overwriteLanguageIndex = getBlockProperty(block, 'overwriteIndexLanguage');
 
@@ -24,7 +26,8 @@ export default async function decorate(block) {
 
   const optionsObject = getBlockPropertiesList(block, 'options');
   const startingFolder = getBlockProperty(block, 'startingFolder');
-  const emptyResultsMessage = getBlockProperty(block, 'emptyResultsMessage');
+  const emptyResultsMessageConfig = getBlockProperty(block, 'emptyResultsMessage');
+  const emptyResultsMessage = await getEmptyResultsMessage(emptyResultsMessageConfig);
   const filterOptions = getListFilterOptions(block, propertyNames);
 
   // If startingFolder is not null, then apply location filter FIRST.

--- a/blocks/listgroup-fixed/listgroup-fixed.js
+++ b/blocks/listgroup-fixed/listgroup-fixed.js
@@ -9,6 +9,7 @@ import {
   getBlockConfig,
   writeImagePropertyInList,
 } from '../../scripts/jmp.js';
+import { getEmptyResultsMessage } from '../../scripts/listgroup.js';
 
 const ogNames = {
   title: 'og:title',
@@ -42,7 +43,7 @@ export default async function decorate(block) {
   const config = getBlockConfig(block);
   block.textContent = '';
 
-  const emptyResultsMessage = config.emptyResultsMessage;
+  const emptyResultsMessage = await getEmptyResultsMessage(config.emptyResultsMessage);
   const pageList = config.pages;
   const columns = config.columns ? config.columns : 5;
 

--- a/blocks/listgroup/listgroup.js
+++ b/blocks/listgroup/listgroup.js
@@ -12,6 +12,8 @@ import {
   filterOutRobotsNoIndexPages,
 } from '../../scripts/jmp.js';
 
+import { getEmptyResultsMessage } from '../../scripts/listgroup.js';
+
 import { getDefaultMetaImage } from '../../scripts/scripts.js';
 
 export default async function decorate(block) {
@@ -24,7 +26,8 @@ export default async function decorate(block) {
 
   const optionsObject = getBlockPropertiesList(block, 'options');
   const startingFolder = getBlockProperty(block, 'startingFolder');
-  const emptyResultsMessage = getBlockProperty(block, 'emptyResultsMessage');
+  const emptyResultsMessageConfig = getBlockProperty(block, 'emptyResultsMessage');
+  const emptyResultsMessage = await getEmptyResultsMessage(emptyResultsMessageConfig);
   const filterOptions = getListFilterOptions(block, propertyNames);
 
   // If startingFolder is not null, then apply page location filter FIRST.

--- a/scripts/listgroup.js
+++ b/scripts/listgroup.js
@@ -1,7 +1,7 @@
 import {
   getLanguage,
   getJsonFromUrl,
- } from './jmp.js';
+} from './jmp.js';
 
 async function getEmptyResultsMessage(emptyResultString) {
   if (!emptyResultString) {
@@ -12,12 +12,10 @@ async function getEmptyResultsMessage(emptyResultString) {
     const pageLanguage = getLanguage();
     const data = await getJsonFromUrl(emptyResultString);
     const { data: translations } = data[pageLanguage];
-    console.log(translations[0]);
     return translations[0].emptyResultsMessage;
-  } else {
-    // use the string as the empty results message. It won't translate.
-    return emptyResultString;
   }
+  // otherwise use the string as the empty results message. It won't translate.
+  return emptyResultString;
 }
 
 export {

--- a/scripts/listgroup.js
+++ b/scripts/listgroup.js
@@ -1,0 +1,25 @@
+import {
+  getLanguage,
+  getJsonFromUrl,
+ } from './jmp.js';
+
+async function getEmptyResultsMessage(emptyResultString) {
+  if (!emptyResultString) {
+    return undefined;
+  }
+
+  if (emptyResultString.includes('.json')) {
+    const pageLanguage = getLanguage();
+    const data = await getJsonFromUrl(emptyResultString);
+    const { data: translations } = data[pageLanguage];
+    console.log(translations[0]);
+    return translations[0].emptyResultsMessage;
+  } else {
+    // use the string as the empty results message. It won't translate.
+    return emptyResultString;
+  }
+}
+
+export {
+  getEmptyResultsMessage,
+};


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--jmp-da--jmphlx.hlx.live/es/sandbox/laurel/sprint-demos/listgroup-translate-empty-message
- After: https://aem-824--jmp-da--jmphlx.hlx.live/es/sandbox/laurel/sprint-demos/listgroup-translate-empty-message

URL for testing:

- https://aem-824--jmp-da--jmphlx.hlx.page/es/sandbox/laurel/sprint-demos/listgroup-translate-empty-message
