### PR TITLE
AEM-396: Refactor listgroup-fixed to work with tags property (and not break on existing pages)

### DIFF
--- a/blocks/listgroup-custom/listgroup-custom.js
+++ b/blocks/listgroup-custom/listgroup-custom.js
@@ -16,13 +16,16 @@ import {
   writeImagePropertyInList,
 } from '../../scripts/jmp.js';
 
-import { getEmptyResultsMessage } from '../../scripts/listgroup.js';
+import {
+  checkForTagProperties,
+  getEmptyResultsMessage,
+  getTagTranslations,
+} from '../../scripts/listgroup.js';
 
 import { loadScript } from '../../scripts/aem.js';
 import { createTag } from '../../scripts/helper.js';
 
 const dateProperties = ['releaseDate'];
-const tagTranslationsBaseURL = 'https://www.jmp.com/services/tagsservlet';
 
 let useFilter = false;
 let useTabs = false;
@@ -62,11 +65,6 @@ function processDate(dateProperty, prop, item) {
     span = `<span class="${prop}">${item[prop]}</span>`;
   }
   return span;
-}
-
-async function getTagTranslations() {
-  const pageLanguage = getLanguage();
-  window.tagtranslations = window.tagtranslations || await getJsonFromUrl(`${tagTranslationsBaseURL}.${pageLanguage}`);
 }
 
 function writeOutTagProperties(prop, item) {
@@ -165,17 +163,6 @@ function checkForDateProperties(displayProperties) {
     }
   }
   return dateFound;
-}
-
-function checkForTagProperties(displayProperties) {
-  let tagFound = false;
-  for (let i = 0; i < displayProperties.length; i++) {
-    if (isTagProperty(displayProperties[i])) {
-      tagFound = true;
-      break;
-    }
-  }
-  return tagFound;
 }
 
 function writeItems(matching, config, listElement) {

--- a/blocks/listgroup-fixed/listgroup-fixed.js
+++ b/blocks/listgroup-fixed/listgroup-fixed.js
@@ -20,6 +20,7 @@ import {
 const ogNames = {
   title: 'og:title',
   image: 'og:image',
+  tags: 'article:tag',
 };
 
 function writeOutTagProperties(prop, doc, propValue) {

--- a/blocks/listgroup-fixed/listgroup-fixed.js
+++ b/blocks/listgroup-fixed/listgroup-fixed.js
@@ -34,7 +34,7 @@ function writeOutTagProperties(prop, doc, propValue) {
   const tagsValue = tagsProperty.split(',');
   const tagsArray = [];
   tagsValue.forEach((tag) => {
-    if (tag.startsWith(convertedProp)) {
+    if (tag.trim().startsWith(convertedProp)) {
       // Found the prop string. Convert it to displayable format
       if (window.tagtranslations[tag]) {
         tagsArray.push(window.tagtranslations[tag]);

--- a/blocks/listgroup-fixed/listgroup-fixed.js
+++ b/blocks/listgroup-fixed/listgroup-fixed.js
@@ -31,7 +31,7 @@ function writeOutTagProperties(prop, doc, propValue) {
   }
 
   const convertedProp = convertCamelToKebabCase(prop);
-  const tagsValue = Object.values(tagsProperty);
+  const tagsValue = tagsProperty.split(',');
   const tagsArray = [];
   tagsValue.forEach((tag) => {
     if (tag.startsWith(convertedProp)) {

--- a/blocks/listgroup-fixed/listgroup-fixed.js
+++ b/blocks/listgroup-fixed/listgroup-fixed.js
@@ -23,7 +23,7 @@ const ogNames = {
 };
 
 function writeOutTagProperties(prop, doc, propValue) {
-  const tagsProperty = getMetaValue(prop, doc);
+  const tagsProperty = getMetaValue('tags', doc);
   if (!tagsProperty || tagsProperty.length < 1 || !window.tagtranslations) {
     // No tags or no translations so default to old method.
     return propValue;

--- a/blocks/listgroup-fixed/listgroup-fixed.js
+++ b/blocks/listgroup-fixed/listgroup-fixed.js
@@ -34,6 +34,7 @@ function writeOutTagProperties(prop, doc, propValue) {
   const tagsValue = tagsProperty.split(',');
   const tagsArray = [];
   tagsValue.forEach((tag) => {
+    tag = tag.trim();
     if (tag.trim().startsWith(convertedProp)) {
       // Found the prop string. Convert it to displayable format
       if (window.tagtranslations[tag]) {

--- a/blocks/listgroup-fixed/listgroup-fixed.js
+++ b/blocks/listgroup-fixed/listgroup-fixed.js
@@ -23,31 +23,6 @@ const ogNames = {
   tags: 'article:tag',
 };
 
-function writeOutTagProperties(prop, doc, propValue) {
-  const tagsProperty = getMetaValue('tags', doc);
-  if (!tagsProperty || tagsProperty.length < 1 || !window.tagtranslations) {
-    // No tags or no translations so default to old method.
-    return propValue;
-  }
-
-  const convertedProp = convertCamelToKebabCase(prop);
-  const tagsValue = tagsProperty.split(',');
-  const tagsArray = [];
-  tagsValue.forEach((tag) => {
-    tag = tag.trim();
-    if (tag.trim().startsWith(convertedProp)) {
-      // Found the prop string. Convert it to displayable format
-      if (window.tagtranslations[tag]) {
-        tagsArray.push(window.tagtranslations[tag]);
-      } else {
-        // Couldn't find translation of prop.
-        tagsArray.push(propValue);
-      }
-    }
-  });
-  return tagsArray.join(', ');
-}
-
 function getMetaValue(prop, doc) {
   let val;
   if (Object.prototype.hasOwnProperty.call(ogNames, prop)) {
@@ -69,6 +44,32 @@ function getMetaValue(prop, doc) {
   }
 
   return val;
+}
+
+function writeOutTagProperties(prop, doc, propValue) {
+  const tagsProperty = getMetaValue('tags', doc);
+  if (!tagsProperty || tagsProperty.length < 1 || !window.tagtranslations) {
+    // No tags or no translations so default to old method.
+    return propValue;
+  }
+
+  const convertedProp = convertCamelToKebabCase(prop);
+  const tagsValue = tagsProperty.split(',');
+  const tagsArray = [];
+  tagsValue.forEach((tag) => {
+    // eslint-disable-next-line no-param-reassign
+    tag = tag.trim();
+    if (tag.trim().startsWith(convertedProp)) {
+      // Found the prop string. Convert it to displayable format
+      if (window.tagtranslations[tag]) {
+        tagsArray.push(window.tagtranslations[tag]);
+      } else {
+        // Couldn't find translation of prop.
+        tagsArray.push(propValue);
+      }
+    }
+  });
+  return tagsArray.join(', ');
 }
 
 export default async function decorate(block) {
@@ -117,7 +118,6 @@ export default async function decorate(block) {
         const pagePropVal = getMetaValue(prop, doc);
         let span;
         if (isTagProperty(prop)) {
-          console.log('found tag property');
           span = `<span class="${prop}">${writeOutTagProperties(prop, doc, pagePropVal)}</span>`;
         } else if (prop === 'image' || prop === 'displayImage') {
           const imageItem = {

--- a/scripts/listgroup.js
+++ b/scripts/listgroup.js
@@ -1,7 +1,15 @@
 import {
   getLanguage,
   getJsonFromUrl,
+  isTagProperty,
 } from './jmp.js';
+
+const tagTranslationsBaseURL = 'https://www.jmp.com/services/tagsservlet';
+
+async function getTagTranslations() {
+  const pageLanguage = getLanguage();
+  window.tagtranslations = window.tagtranslations || await getJsonFromUrl(`${tagTranslationsBaseURL}.${pageLanguage}`);
+}
 
 async function getEmptyResultsMessage(emptyResultString) {
   if (!emptyResultString) {
@@ -18,6 +26,19 @@ async function getEmptyResultsMessage(emptyResultString) {
   return emptyResultString;
 }
 
+function checkForTagProperties(displayProperties) {
+  let tagFound = false;
+  for (let i = 0; i < displayProperties.length; i++) {
+    if (isTagProperty(displayProperties[i])) {
+      tagFound = true;
+      break;
+    }
+  }
+  return tagFound;
+}
+
 export {
+  checkForTagProperties,
   getEmptyResultsMessage,
+  getTagTranslations,
 };


### PR DESCRIPTION
Refactored listgroup-fixed to make it work with the tags property. If the tags property doesn't exist, continue using old method.

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--jmp-da--jmphlx.aem.live/es/sandbox/laurel/sprint-demos/listgroup-refactor
- After: https://aem-396--jmp-da--jmphlx.aem.live/es/sandbox/laurel/sprint-demos/listgroup-refactor

URL for testing:

- https://aem-396--jmp-da--jmphlx.aem.page/es/sandbox/laurel/sprint-demos/listgroup-refactor
