### PR TITLE
Allow getJsonFromUrl to cache to prevent duplicate calls to index

### DIFF
--- a/scripts/jmp.js
+++ b/scripts/jmp.js
@@ -1,4 +1,5 @@
 const defaultMetaImage = `${window.location.origin}/icons/jmp-com-share.jpg`;
+const jsonCache = {};
 
 function getDefaultMetaImage() {
   return defaultMetaImage;
@@ -76,10 +77,15 @@ function arrayIncludesSomeValues(filterValues, pageValues) {
  * @returns {Object} the json data object
 */
 async function getJsonFromUrl(route) {
+  if (jsonCache[route]) {
+    return jsonCache[route];
+  }
+
   try {
     const response = await window.fetch(route);
     if (!response.ok) return null;
     const json = await response.json();
+    jsonCache[route] = json;
     return json;
   } catch (error) {
     // eslint-disable-next-line no-console
@@ -534,9 +540,16 @@ function setTabFromHash(button, tabpanel) {
   button.setAttribute('aria-selected', true);
 }
 
+function clearJsonCache() {
+  Object.keys(jsonCache).forEach((key) => {
+    delete jsonCache[key];
+  });
+}
+
 export {
   arrayIncludesAllValues,
   arrayIncludesSomeValues,
+  clearJsonCache,
   containsOperator,
   convertCamelToKebabCase,
   debounce,

--- a/test/blocks/listgroup-custom/listgroup-custom.test.js
+++ b/test/blocks/listgroup-custom/listgroup-custom.test.js
@@ -4,6 +4,7 @@ import { readFile } from '@web/test-runner-commands';
 import sinon from 'sinon';
 
 const { decorateBlock, loadBlock } = await import('../../../scripts/aem.js');
+const { clearJsonCache } = await import('../../../scripts/jmp.js');
 
 const pagedata = await readFile({ path: './test-index.json' });
 const querydata = await readFile({ path: './custom-query.json' });
@@ -48,6 +49,7 @@ describe('Custom Listgroup', () => {
     });
 
     after(async () => {
+      clearJsonCache();
       stub.reset();
     });
   });
@@ -70,6 +72,7 @@ describe('Custom Listgroup', () => {
     });
 
     after(async () => {
+      clearJsonCache();
       stub.reset();
     });
   });
@@ -106,6 +109,7 @@ describe('Custom Listgroup', () => {
     });
 
     after(async () => {
+      clearJsonCache();
       stub.reset();
     });
   });
@@ -159,14 +163,22 @@ describe('Custom Listgroup', () => {
   });
 
   describe('Tabs', () => {
+    let tabsHtml;
+
     before(async () => {
+      tabsHtml = await readFile({ path: './tabsListgroup.html' });
+    });
+
+    beforeEach(async () => {
+      clearJsonCache();
       stub.onCall(0).returns(jsonOk(JSON.parse(pagedata)));
       stub.onCall(1).returns(jsonOk(JSON.parse(multipageQueryData)));
-      document.body.innerHTML = await readFile({ path: './tabsListgroup.html' });
+      document.body.innerHTML = tabsHtml;
       const listgroupBlock = document.querySelector('.listgroup-custom');
       document.querySelector('main').append(listgroupBlock);
       decorateBlock(listgroupBlock);
       await loadBlock(listgroupBlock);
+      stub.resetHistory();
     });
 
     it('When using tabs, tab list is created using Tabs property', async () => {
@@ -216,6 +228,7 @@ describe('Custom Listgroup', () => {
 
 
     after(async () => {
+      clearJsonCache();
       stub.reset();
     });
   });
@@ -237,6 +250,7 @@ describe('Custom Listgroup', () => {
     });
 
     after(async () => {
+      clearJsonCache();
       stub.reset();
     });
   });
@@ -258,6 +272,7 @@ describe('Custom Listgroup', () => {
     });
 
     after(async () => {
+      clearJsonCache();
       stub.reset();
     });
   });
@@ -300,6 +315,7 @@ describe('Custom Listgroup', () => {
     });
 
     after(async () => {
+      clearJsonCache();
       stub.reset();
     });
   });
@@ -327,6 +343,7 @@ describe('Custom Listgroup', () => {
     });
 
     after(async () => {
+      clearJsonCache();
       stub.reset();
     });
   });
@@ -451,6 +468,7 @@ describe('Custom Listgroup', () => {
     });
 
     after(async () => {
+      clearJsonCache();
       stub.reset();
     });
   });

--- a/test/scripts/search.test.js
+++ b/test/scripts/search.test.js
@@ -3,6 +3,7 @@ import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 
 const searchHelper = await import('../../scripts/search.js');
+const { clearJsonCache } = await import('../../scripts/jmp.js');
 
 const cardTemplate = (title, description, href, displayUrl) => `<div class="results-body"><a class="title" href="${href}">${title}</a>` +
 `<p class="description">${description}</p><a class="displayUrl" href="${href}">${displayUrl}</a></div>`;
@@ -163,6 +164,7 @@ describe('Search Script ', () => {
     let fetchStub;
 
     beforeEach(() => {
+      clearJsonCache();
       window.commonsSheet = undefined;
       fetchStub = sinon.stub(window, 'fetch');
     });


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--jmp-da--jmphlx.aem.live/en/resources/resource-listings/featured
- After: https://aem-1005--jmp-da--jmphlx.aem.live/en/resources/resource-listings/featured

URL for testing:

- https://aem-1005--jmp-da--jmphlx.aem.page/en/resources/resource-listings/featured
