### PR TITLE
New relic consent fix

### DIFF
--- a/head.html
+++ b/head.html
@@ -48,6 +48,18 @@
       console.log('found functional cookie consent NR');
       const script = document.createElement('script');
       script.src = '/scripts/newrelic.js';
+      // newrelic.js runs with browser_consent_mode enabled, so the agent withholds
+      // all data until consent is explicitly granted. We only reach here when the
+      // functional consent cookie is present, so propagate that consent to the agent.
+      script.addEventListener('load', function () {
+        try {
+          if (window.newrelic && typeof window.newrelic.consent === 'function') {
+            window.newrelic.consent(true);
+          }
+        } catch (e) {
+          // no-op: never block page load on consent propagation
+        }
+      });
       document.head.appendChild(script);
     }
     if (nrHasConsent()) {

--- a/head.html
+++ b/head.html
@@ -48,9 +48,6 @@
       console.log('found functional cookie consent NR');
       const script = document.createElement('script');
       script.src = '/scripts/newrelic.js';
-      // newrelic.js runs with browser_consent_mode enabled, so the agent withholds
-      // all data until consent is explicitly granted. We only reach here when the
-      // functional consent cookie is present, so propagate that consent to the agent.
       script.addEventListener('load', function () {
         try {
           if (window.newrelic && typeof window.newrelic.consent === 'function') {


### PR DESCRIPTION
New Relic consent mode is not properly sending POSTs on returning visitor. 

Test URLs:
- Before: https://www.jmp.com/en/home
- After: https://new-relic-consent-fix--jmp-da--jmphlx.aem.page/en/home

Steps for testing: 
- Navigate to testing URL
- Simulate a consented visitor with: `document.cookie = 'cmapi_cookie_privacy=permit 1,2,3; path=/';
location.reload();`
- Ignore the new relic loading chunk error, it is an error from being on the preview side of things
- Run this on both page consoles: 
    - `const a = Object.values(NREUM.initializedAgents)[0];
a?.runtime?.consented`  
    -  JMP.com expected output: `false`
    - branch preview expected output: `true`

`true` on the branch preview means that the consent flag has been properly passed to NR.
