### PR TITLE
DO NOT MERGE: AEM-1039: Redirect passed events

### DIFF
--- a/.github/workflows/unpublish-past-events-amer.yml
+++ b/.github/workflows/unpublish-past-events-amer.yml
@@ -1,8 +1,5 @@
 name: AMER/EU Unpublish Past Events
 on:
-  schedule:
-    # * is a special character in YAML so you have to quote this string
-    - cron:  '10 22 * * *' #  run at 5:10PM for Americas and Europe
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/unpublish-past-events-apac.yml
+++ b/.github/workflows/unpublish-past-events-apac.yml
@@ -1,8 +1,5 @@
 name: APAC Unpublish Past Events
 on:
-  schedule:
-    # * is a special character in YAML so you have to quote this string
-    - cron:  '10 8 * * *' # run at 5:10PM for APAC
   workflow_dispatch:
 
 jobs:

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -642,17 +642,31 @@ function addTargetsToLinks(doc) {
 }
 
 /**
+* If there is a redirectTarget, determine redirect logic.
+* If there is a offDateTime along with redirectTarget, wait until
+* after off time has passed to redirect.
+* If there is no offDateTime, redirect to redirect target immediately.
+*/
+function handleRedirect() {
+  const redirectTarget = getMetadata('redirecttarget');
+  if (redirectTarget.length > 0) {
+    const offDateTime = getMetadata('offdatetime');
+    if (offDateTime.length > 0) {
+      if (new Date(offDateTime) <= new Date()) {
+        window.location.href = redirectTarget;
+      }
+    } else {
+      window.location.href = redirectTarget;
+    }
+  }
+}
+
+/**
  * Loads everything needed to get to LCP.
  * @param {Element} doc The container element
  */
 async function loadEager(doc) {
-  // If there is a redirectTarget in the page metadata, immediately
-  // redirect to target.
-  const redirectTarget = getMetadata('redirecttarget');
-  if (redirectTarget.length > 0) {
-    window.location.href = redirectTarget;
-  }
-
+  handleRedirect();
   addTitleSuffix();
   setMetaImage();
   decorateTemplateAndTheme();


### PR DESCRIPTION
Turn off schedule for unpublish workflows and add redirectTarget logic with offDateTime

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--jmp-da--jmphlx.aem.live/en/events/americas/live-webinars/getting-started-with-jmp/2026/04-09
- After: https://aem-1039--jmp-da--jmphlx.aem.live/en/events/americas/live-webinars/getting-started-with-jmp/2026/04-09

URL for testing:

- https://aem-1039--jmp-da--jmphlx.aem.page/en/events/americas/live-webinars/getting-started-with-jmp/2026/04-09
